### PR TITLE
AlamofireとSwiftyJSONを追加

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,2 @@
+github "Alamofire/Alamofire" ~> 4.5
+github "SwiftyJSON/SwiftyJSON"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,2 @@
+github "Alamofire/Alamofire" "4.5.1"
+github "SwiftyJSON/SwiftyJSON" "3.1.4"

--- a/piyopiyo.xcodeproj/project.pbxproj
+++ b/piyopiyo.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AF087D8E1F78E3DB006C6BAF /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF087D8C1F78E3DB006C6BAF /* SwiftyJSON.framework */; };
+		AF087D8F1F78E3DB006C6BAF /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF087D8D1F78E3DB006C6BAF /* Alamofire.framework */; };
 		AF161EEF1F78A6FF00B2DD73 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF161EEE1F78A6FF00B2DD73 /* AppDelegate.swift */; };
 		AF161EF11F78A6FF00B2DD73 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF161EF01F78A6FF00B2DD73 /* ViewController.swift */; };
 		AF161EF41F78A6FF00B2DD73 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AF161EF21F78A6FF00B2DD73 /* Main.storyboard */; };
@@ -34,6 +36,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		AF087D8C1F78E3DB006C6BAF /* SwiftyJSON.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyJSON.framework; path = Carthage/Build/iOS/SwiftyJSON.framework; sourceTree = "<group>"; };
+		AF087D8D1F78E3DB006C6BAF /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
 		AF161EEB1F78A6FF00B2DD73 /* piyopiyo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = piyopiyo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF161EEE1F78A6FF00B2DD73 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AF161EF01F78A6FF00B2DD73 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -54,6 +58,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AF087D8E1F78E3DB006C6BAF /* SwiftyJSON.framework in Frameworks */,
+				AF087D8F1F78E3DB006C6BAF /* Alamofire.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -74,6 +80,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		AF087D8B1F78E3DB006C6BAF /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				AF087D8D1F78E3DB006C6BAF /* Alamofire.framework */,
+				AF087D8C1F78E3DB006C6BAF /* SwiftyJSON.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		AF161EE21F78A6FF00B2DD73 = {
 			isa = PBXGroup;
 			children = (
@@ -81,6 +96,7 @@
 				AF161F021F78A6FF00B2DD73 /* piyopiyoTests */,
 				AF161F0D1F78A6FF00B2DD73 /* piyopiyoUITests */,
 				AF161EEC1F78A6FF00B2DD73 /* Products */,
+				AF087D8B1F78E3DB006C6BAF /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -262,12 +278,14 @@
 			files = (
 			);
 			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/Alamofire.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/SwiftyJSON.framework",
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n\nif which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -444,6 +462,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = piyopiyo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pepabo.piyopiyo;
@@ -458,6 +480,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = piyopiyo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pepabo.piyopiyo;


### PR DESCRIPTION
### 何を解決するのか
AlamofireとSwiftyJSONを導入し、API通信周りを楽にする

### 詳細
- Cartfileを追加
- [Alamofire](https://github.com/Alamofire/Alamofire)・[SwiftyJSON](https://github.com/SwiftyJSON/SwiftyJSON)を追加

### 期日
下記のどちらかより前
- 他のライブラリを導入する
- API通信周りの実装開始

### レビューポイント
- `Cartfile`：記述が適切かどうか

### レビュアー
@piyoppi 