### PR TITLE
CIにテストコマンドを記述してテストを実行する

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 osx_image: xcode9
 language: objective-c
 cache:
-    directories:
+  directories:
     - Carthage
 before_install:
-    - carthage bootstrap --platform iOS --cache-builds
+  - carthage bootstrap --platform iOS --cache-builds
 script:
-    - xcodebuild clean && xcodebuild build -project piyopiyo.xcodeproj -scheme piyopiyo CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
-    - xcodebuild test -workspace piyopiyo.xcodeproj/project.xcworkspace -scheme piyopiyoTests -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s" 
-    - xcodebuild test -workspace piyopiyo.xcodeproj/project.xcworkspace -scheme piyopiyoUITests -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s" 
+  - xcodebuild clean && xcodebuild build -project piyopiyo.xcodeproj -scheme piyopiyo CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
+  - xcodebuild test -workspace piyopiyo.xcodeproj/project.xcworkspace -scheme piyopiyoTests -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s"
+  - xcodebuild test -workspace piyopiyo.xcodeproj/project.xcworkspace -scheme piyopiyoUITests -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s"
 notifications:
   slack:
     secure: LvfKw6RbhwSnQauScpbd9cpTOQFNubhkDkMchAYimeAT5/AUlGpErAZ9xw1/N8/nLvQSKb/+mbjoTFZ3IIdRWG69a1o0yiQ8SVUnuon7IaB5Uoy724bsT63iJ6X9ZQAsr+LAtkIOnS7/45WVPOjQCZ0h3G412sXJwUKzIq8y1ytaqn551KSLvHkJxPHh279tDBEAhjg7sDTd0CedWGFNt3YIIqwC+cF9jdfORBrzmhPOPol2Lvz6Z1gzPMSHadeefXmrr/mtHQtkWQRHlhPtoet9AFcGusBTJvPW3Ybzgbi9J7mRJq9r8leZkvyWf87PdOZJDVIK6H034cPVc9IBtXHwVxmgga+NlDuVdoxCpkI/TG2uIUMu2RrCbto7XO+BGjr5us9jYK1PzdodK0EwLehkmgklUolBmznLcHX9koMmk4zKe0okghBNYVaCRu3DUK3m+KwwwWCYfPofIzPnWBgqJDxWx3P9/7QKYnJnOTeJqBsOtW76kQtWHPfHDdzRnljrEeUaO5ATCqcFLbfvvL8zkfq5TyqxBel9IbkISqD+37VKOTzCOjDnRL6aVbvEiczanmTgsDeBoEnZx5XgWlP7hvL9RFq4e1mPgFouO+eMN2MsjQVAEeQLuu3eAIQ/Qwa1Q2vxUYqGQ6rjj8aFbQZV8RgofJ2mBSyD6HDeQTU=

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: objective-c
 script:
     - xcodebuild clean && xcodebuild build -project piyopiyo.xcodeproj -scheme piyopiyo CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
     - xcodebuild test -workspace piyopiyo.xcodeproj/project.xcworkspace -scheme piyopiyoTests -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s" 
+    - xcodebuild test -workspace piyopiyo.xcodeproj/project.xcworkspace -scheme piyopiyoUITests -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s" 
 notifications:
   slack:
     secure: LvfKw6RbhwSnQauScpbd9cpTOQFNubhkDkMchAYimeAT5/AUlGpErAZ9xw1/N8/nLvQSKb/+mbjoTFZ3IIdRWG69a1o0yiQ8SVUnuon7IaB5Uoy724bsT63iJ6X9ZQAsr+LAtkIOnS7/45WVPOjQCZ0h3G412sXJwUKzIq8y1ytaqn551KSLvHkJxPHh279tDBEAhjg7sDTd0CedWGFNt3YIIqwC+cF9jdfORBrzmhPOPol2Lvz6Z1gzPMSHadeefXmrr/mtHQtkWQRHlhPtoet9AFcGusBTJvPW3Ybzgbi9J7mRJq9r8leZkvyWf87PdOZJDVIK6H034cPVc9IBtXHwVxmgga+NlDuVdoxCpkI/TG2uIUMu2RrCbto7XO+BGjr5us9jYK1PzdodK0EwLehkmgklUolBmznLcHX9koMmk4zKe0okghBNYVaCRu3DUK3m+KwwwWCYfPofIzPnWBgqJDxWx3P9/7QKYnJnOTeJqBsOtW76kQtWHPfHDdzRnljrEeUaO5ATCqcFLbfvvL8zkfq5TyqxBel9IbkISqD+37VKOTzCOjDnRL6aVbvEiczanmTgsDeBoEnZx5XgWlP7hvL9RFq4e1mPgFouO+eMN2MsjQVAEeQLuu3eAIQ/Qwa1Q2vxUYqGQ6rjj8aFbQZV8RgofJ2mBSyD6HDeQTU=

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ before_install:
 - carthage update --platform ios
 osx_image: xcode9
 language: objective-c
-script: xcodebuild clean && xcodebuild build -project piyopiyo.xcodeproj -scheme piyopiyo
-  CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
+script:
+    - xcodebuild clean && xcodebuild build -project piyopiyo.xcodeproj -scheme piyopiyo CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
+    - xcodebuild test -workspace piyopiyo.xcodeproj/project.xcworkspace -scheme piyopiyoTests -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s" 
 notifications:
   slack:
     secure: LvfKw6RbhwSnQauScpbd9cpTOQFNubhkDkMchAYimeAT5/AUlGpErAZ9xw1/N8/nLvQSKb/+mbjoTFZ3IIdRWG69a1o0yiQ8SVUnuon7IaB5Uoy724bsT63iJ6X9ZQAsr+LAtkIOnS7/45WVPOjQCZ0h3G412sXJwUKzIq8y1ytaqn551KSLvHkJxPHh279tDBEAhjg7sDTd0CedWGFNt3YIIqwC+cF9jdfORBrzmhPOPol2Lvz6Z1gzPMSHadeefXmrr/mtHQtkWQRHlhPtoet9AFcGusBTJvPW3Ybzgbi9J7mRJq9r8leZkvyWf87PdOZJDVIK6H034cPVc9IBtXHwVxmgga+NlDuVdoxCpkI/TG2uIUMu2RrCbto7XO+BGjr5us9jYK1PzdodK0EwLehkmgklUolBmznLcHX9koMmk4zKe0okghBNYVaCRu3DUK3m+KwwwWCYfPofIzPnWBgqJDxWx3P9/7QKYnJnOTeJqBsOtW76kQtWHPfHDdzRnljrEeUaO5ATCqcFLbfvvL8zkfq5TyqxBel9IbkISqD+37VKOTzCOjDnRL6aVbvEiczanmTgsDeBoEnZx5XgWlP7hvL9RFq4e1mPgFouO+eMN2MsjQVAEeQLuu3eAIQ/Qwa1Q2vxUYqGQ6rjj8aFbQZV8RgofJ2mBSyD6HDeQTU=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
-before_install:
-- carthage update --platform ios
 osx_image: xcode9
 language: objective-c
+cache:
+    directories:
+    - Carthage
+before_install:
+    - carthage bootstrap --platform iOS --cache-builds
 script:
     - xcodebuild clean && xcodebuild build -project piyopiyo.xcodeproj -scheme piyopiyo CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
     - xcodebuild test -workspace piyopiyo.xcodeproj/project.xcworkspace -scheme piyopiyoTests -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ before_install:
   - carthage bootstrap --platform iOS --cache-builds
 script:
   - xcodebuild clean && xcodebuild build -project piyopiyo.xcodeproj -scheme piyopiyo CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
-  - xcodebuild test -workspace piyopiyo.xcodeproj/project.xcworkspace -scheme piyopiyoTests -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s"
-  - xcodebuild test -workspace piyopiyo.xcodeproj/project.xcworkspace -scheme piyopiyoUITests -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s"
+  - xcodebuild test -workspace piyopiyo.xcodeproj/project.xcworkspace -scheme piyopiyoTests -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 8"
+  - xcodebuild test -workspace piyopiyo.xcodeproj/project.xcworkspace -scheme piyopiyoUITests -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 8"
 notifications:
   slack:
     secure: LvfKw6RbhwSnQauScpbd9cpTOQFNubhkDkMchAYimeAT5/AUlGpErAZ9xw1/N8/nLvQSKb/+mbjoTFZ3IIdRWG69a1o0yiQ8SVUnuon7IaB5Uoy724bsT63iJ6X9ZQAsr+LAtkIOnS7/45WVPOjQCZ0h3G412sXJwUKzIq8y1ytaqn551KSLvHkJxPHh279tDBEAhjg7sDTd0CedWGFNt3YIIqwC+cF9jdfORBrzmhPOPol2Lvz6Z1gzPMSHadeefXmrr/mtHQtkWQRHlhPtoet9AFcGusBTJvPW3Ybzgbi9J7mRJq9r8leZkvyWf87PdOZJDVIK6H034cPVc9IBtXHwVxmgga+NlDuVdoxCpkI/TG2uIUMu2RrCbto7XO+BGjr5us9jYK1PzdodK0EwLehkmgklUolBmznLcHX9koMmk4zKe0okghBNYVaCRu3DUK3m+KwwwWCYfPofIzPnWBgqJDxWx3P9/7QKYnJnOTeJqBsOtW76kQtWHPfHDdzRnljrEeUaO5ATCqcFLbfvvL8zkfq5TyqxBel9IbkISqD+37VKOTzCOjDnRL6aVbvEiczanmTgsDeBoEnZx5XgWlP7hvL9RFq4e1mPgFouO+eMN2MsjQVAEeQLuu3eAIQ/Qwa1Q2vxUYqGQ6rjj8aFbQZV8RgofJ2mBSyD6HDeQTU=

--- a/piyopiyoTests/piyopiyoTests.swift
+++ b/piyopiyoTests/piyopiyoTests.swift
@@ -24,7 +24,6 @@ class PiyopiyoTests: XCTestCase {
     func testExample() {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
-        XCTAssertTrue(false)
     }
     
     func testPerformanceExample() {

--- a/piyopiyoTests/piyopiyoTests.swift
+++ b/piyopiyoTests/piyopiyoTests.swift
@@ -24,6 +24,7 @@ class PiyopiyoTests: XCTestCase {
     func testExample() {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
+        XCTAssertTrue(false)
     }
     
     func testPerformanceExample() {


### PR DESCRIPTION
### 何を解決するのか
- CIにテストコマンドを記述することで、push時にビルドに加えてテストが走るようにした
- ついでにCarthageビルドの結果をキャッシュして次回以降に使えるようにした
    - テスト結果が得られるまでの時間が短くなった

### 詳細
- 作業ログ： #4 

### 期日
なるべく早く

### レビューポイント
- .travis.yml
    - Carthageの結果をキャッシュする記述
    - xcodebuildでテストを実行する記述を追加

### レビュアー
@shizunaito @Asuforce
