### PR TITLE
TutorialViewをFeedに表示させる

### DIFF
--- a/piyopiyo.xcodeproj/project.pbxproj
+++ b/piyopiyo.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		AFBDE5BD1F7A268200441353 /* .gitkeep in Resources */ = {isa = PBXBuildFile; fileRef = AFBDE5BC1F7A268200441353 /* .gitkeep */; };
 		AFBDE5C31F7A34F000441353 /* BalloonView.xib in Resources */ = {isa = PBXBuildFile; fileRef = AFBDE5C21F7A34F000441353 /* BalloonView.xib */; };
 		AFBDE5C51F7A390C00441353 /* BalloonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBDE5C41F7A390C00441353 /* BalloonView.swift */; };
+		AFECFAD31F7DF321001A9A0E /* FeedUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFECFAD21F7DF321001A9A0E /* FeedUITests.swift */; };
 		E4F700641F7A260700869BD5 /* TutorialView.xib in Resources */ = {isa = PBXBuildFile; fileRef = E4F700631F7A260700869BD5 /* TutorialView.xib */; };
 		E4F700661F7A2FBD00869BD5 /* ColorButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F700651F7A2FBD00869BD5 /* ColorButton.swift */; };
 		E4F700681F7A4BEA00869BD5 /* ProfileView.xib in Resources */ = {isa = PBXBuildFile; fileRef = E4F700671F7A4BEA00869BD5 /* ProfileView.xib */; };
@@ -66,6 +67,7 @@
 		AFBDE5BC1F7A268200441353 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		AFBDE5C21F7A34F000441353 /* BalloonView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BalloonView.xib; sourceTree = "<group>"; };
 		AFBDE5C41F7A390C00441353 /* BalloonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalloonView.swift; sourceTree = "<group>"; };
+		AFECFAD21F7DF321001A9A0E /* FeedUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedUITests.swift; sourceTree = "<group>"; };
 		E4F700631F7A260700869BD5 /* TutorialView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TutorialView.xib; sourceTree = "<group>"; };
 		E4F700651F7A2FBD00869BD5 /* ColorButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorButton.swift; sourceTree = "<group>"; };
 		E4F700671F7A4BEA00869BD5 /* ProfileView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProfileView.xib; sourceTree = "<group>"; };
@@ -230,6 +232,7 @@
 			isa = PBXGroup;
 			children = (
 				AF161F0E1F78A6FF00B2DD73 /* piyopiyoUITests.swift */,
+				AFECFAD21F7DF321001A9A0E /* FeedUITests.swift */,
 				AF161F101F78A6FF00B2DD73 /* Info.plist */,
 			);
 			path = piyopiyoUITests;
@@ -416,6 +419,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AF161F0F1F78A6FF00B2DD73 /* piyopiyoUITests.swift in Sources */,
+				AFECFAD31F7DF321001A9A0E /* FeedUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -23,19 +23,35 @@ class FeedViewController: UIViewController {
     static let initialBalloonY = screenSize.height - bottomMargin
 
     private let balloonView = BalloonView(frame: CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0))
+    private var tutorialView: TutorialView?
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        addTutorial()
+
+        tutorialView = TutorialView(frame: self.view.frame)
+        if let tutorialView = tutorialView {
+            addTutorial(tutorialView: tutorialView)
+        }
+    }
+
+    private func addTutorial(tutorialView: TutorialView?) {
+        guard let tutorialView = tutorialView else {
+            return
+        }
+
+        tutorialView.startButton.addTarget(self, action: #selector(self.startButtonDidTap(_:)), for: .touchUpInside)
+        view.addSubview(tutorialView)
+    }
+
+    @objc private func startButtonDidTap(_ sender: UIButton) {
+        guard let tutorialView = tutorialView else {
+            return
+        }
+
+        tutorialView.removeFromSuperview()
         
         view.addSubview(balloonView)
         animateBalloon()
-    }
-    
-    private func addTutorial() {
-        let tutorialView = TutorialView(frame: self.view.frame)
-        view.addSubview(tutorialView)
     }
 
     private func animateBalloon() {

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class FeedViewController: UIViewController {
+class FeedViewController: UIViewController, TutorialDelegate {
 
     static let screenSize = UIScreen.main.bounds.size
     static let hiyokoHeight: CGFloat = 100.0
@@ -30,6 +30,7 @@ class FeedViewController: UIViewController {
 
         tutorialView = TutorialView(frame: self.view.frame)
         if let tutorialView = tutorialView {
+            tutorialView.delegate = self
             addTutorial(tutorialView: tutorialView)
         }
     }
@@ -39,17 +40,11 @@ class FeedViewController: UIViewController {
             return
         }
 
-        tutorialView.startButton.addTarget(self, action: #selector(self.startButtonDidTap(_:)), for: .touchUpInside)
         view.addSubview(tutorialView)
     }
 
-    @objc private func startButtonDidTap(_ sender: UIButton) {
-        guard let tutorialView = tutorialView else {
-            return
-        }
-
-        tutorialView.removeFromSuperview()
-        
+    
+    func startButtonDidTap() {
         view.addSubview(balloonView)
         animateBalloon()
     }

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -27,8 +27,15 @@ class FeedViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        addTutorial()
+        
         view.addSubview(balloonView)
         animateBalloon()
+    }
+    
+    private func addTutorial() {
+        let tutorialView = TutorialView(frame: self.view.frame)
+        view.addSubview(tutorialView)
     }
 
     private func animateBalloon() {

--- a/piyopiyo/Classes/Views/TutorialView.swift
+++ b/piyopiyo/Classes/Views/TutorialView.swift
@@ -10,6 +10,8 @@ import UIKit
 
 class TutorialView: UIView {
 
+    @IBOutlet weak var startButton: ColorButton!
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setup()

--- a/piyopiyo/Classes/Views/TutorialView.swift
+++ b/piyopiyo/Classes/Views/TutorialView.swift
@@ -8,8 +8,13 @@
 
 import UIKit
 
+protocol TutorialDelegate: class {
+    func startButtonDidTap()
+}
+
 class TutorialView: UIView {
 
+    weak var delegate: TutorialDelegate?
     @IBOutlet weak var startButton: ColorButton!
 
     override init(frame: CGRect) {
@@ -30,4 +35,8 @@ class TutorialView: UIView {
         addSubview(view)
     }
     
+    @IBAction func startButtonDidTap(_ sender: ColorButton) {
+        removeFromSuperview()
+        delegate?.startButtonDidTap()
+    }
 }

--- a/piyopiyo/Xibs/BalloonView.xib
+++ b/piyopiyo/Xibs/BalloonView.xib
@@ -24,6 +24,7 @@
                 </imageView>
                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" usesAttributedText="YES" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f9c-EM-a9B">
                     <rect key="frame" x="20" y="13" width="223" height="111"/>
+                    <accessibility key="accessibilityConfiguration" identifier="commentLabel"/>
                     <attributedString key="attributedText">
                         <fragment content="今日はいい天気だなあ。朝食も美味しかったなあ。">
                             <attributes>

--- a/piyopiyo/Xibs/TutorialView.xib
+++ b/piyopiyo/Xibs/TutorialView.xib
@@ -42,6 +42,7 @@
                 </imageView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="khC-Ep-hpp" customClass="ColorButton" customModule="piyopiyo" customModuleProvider="target">
                     <rect key="frame" x="35" y="458" width="250" height="50"/>
+                    <accessibility key="accessibilityConfiguration" identifier="startButton"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="250" id="XI5-WV-dvh"/>
                         <constraint firstAttribute="height" constant="50" id="m3w-FK-ZnX"/>

--- a/piyopiyo/Xibs/TutorialView.xib
+++ b/piyopiyo/Xibs/TutorialView.xib
@@ -10,7 +10,11 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TutorialView" customModule="piyopiyo" customModuleProvider="target"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TutorialView" customModule="piyopiyo" customModuleProvider="target">
+            <connections>
+                <outlet property="startButton" destination="khC-Ep-hpp" id="M6L-xt-BLO"/>
+            </connections>
+        </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
             <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>

--- a/piyopiyo/Xibs/TutorialView.xib
+++ b/piyopiyo/Xibs/TutorialView.xib
@@ -58,6 +58,9 @@
                             <real key="value" value="25"/>
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="startButtonDidTap:" destination="-1" eventType="touchUpInside" id="nR1-Lo-cmS"/>
+                    </connections>
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="91m-OZ-h2j">
                     <rect key="frame" x="10" y="155" width="300" height="90"/>

--- a/piyopiyoUITests/FeedUITests.swift
+++ b/piyopiyoUITests/FeedUITests.swift
@@ -1,0 +1,35 @@
+//
+//  FeedUITests.swift
+//  piyopiyoUITests
+//
+//  Created by shizuna.ito on 2017/09/29.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import XCTest
+
+class FeedUITests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+
+        continueAfterFailure = false
+        XCUIApplication().launch()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testRemoveFromFeed() {
+        let app = XCUIApplication()
+        
+        let startButton = app.buttons["startButton"]
+        
+        XCTAssert(startButton.exists)
+        
+        startButton.tap()
+        
+        XCTAssertFalse(startButton.exists)
+    }
+}

--- a/piyopiyoUITests/FeedUITests.swift
+++ b/piyopiyoUITests/FeedUITests.swift
@@ -25,13 +25,13 @@ class FeedUITests: XCTestCase {
         let app = XCUIApplication()
         let startButton = app.buttons["startButton"]
         let commentTextView = app.textViews["commentLabel"]
-        let duration: TimeInterval = 5.0
+        let durationOfBalloon: TimeInterval = 5.0
         
         XCTAssert(startButton.exists)
         
         startButton.tap()
         XCTAssertFalse(startButton.exists)
 
-        XCTAssert(commentTextView.waitForExistence(timeout: duration))
+        XCTAssert(commentTextView.waitForExistence(timeout: durationOfBalloon))
     }
 }

--- a/piyopiyoUITests/FeedUITests.swift
+++ b/piyopiyoUITests/FeedUITests.swift
@@ -21,15 +21,17 @@ class FeedUITests: XCTestCase {
         super.tearDown()
     }
     
-    func testRemoveFromFeed() {
+    func testTapAppStart() {
         let app = XCUIApplication()
-        
         let startButton = app.buttons["startButton"]
+        let commentTextView = app.textViews["commentLabel"]
+        let duration: TimeInterval = 5.0
         
         XCTAssert(startButton.exists)
         
         startButton.tap()
-        
         XCTAssertFalse(startButton.exists)
+
+        XCTAssert(commentTextView.waitForExistence(timeout: duration))
     }
 }


### PR DESCRIPTION
### 何を解決するのか
TutorialViewをFeedVCに表示させて、「はじめる」ボタンを押すと下記を実行する
- TutorialViewをsubViewから消す
- BalloonViewをsubViewに追加する

#### やらないこと
アプリの初回起動判定

### 詳細
作業ログ： #27 

- [x] TutorialViewをFeedVCに追加
- [x] 「はじめる」ボタンにアクションを追加
- [x] テストを追加

### 期日
次の遷移前（なるべく早めで）

### レビューポイント
- `TutorialView.swift`
  - `TutorialDelegate`：startButtonタップ時の処理用のdelegationを追加
  - startButtonタップ時のアクションを追加
- `FeedViewController.swift`
  - `TutorialDelegate`を準拠するための実装を追加
- `FeedUITests.swift`：tuitorialのボタンタップ時のUIテストを追加

### レビュアー
@piyoppi @Asuforce 