### PR TITLE
ランダムなMicropostを取得するためのAPI通信機能の実装

### DIFF
--- a/piyopiyo.xcodeproj/project.pbxproj
+++ b/piyopiyo.xcodeproj/project.pbxproj
@@ -21,15 +21,17 @@
 		AFBDE5BD1F7A268200441353 /* .gitkeep in Resources */ = {isa = PBXBuildFile; fileRef = AFBDE5BC1F7A268200441353 /* .gitkeep */; };
 		AFBDE5C31F7A34F000441353 /* BalloonView.xib in Resources */ = {isa = PBXBuildFile; fileRef = AFBDE5C21F7A34F000441353 /* BalloonView.xib */; };
 		AFBDE5C51F7A390C00441353 /* BalloonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBDE5C41F7A390C00441353 /* BalloonView.swift */; };
-		E4744B761F7CEC2D0013619D /* UserFeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4744B751F7CEC2D0013619D /* UserFeedTests.swift */; };
 		AFECFAD31F7DF321001A9A0E /* FeedUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFECFAD21F7DF321001A9A0E /* FeedUITests.swift */; };
+		E4744B761F7CEC2D0013619D /* UserFeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4744B751F7CEC2D0013619D /* UserFeedTests.swift */; };
+		E4D89DA01F833AE1006A419A /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D89D9F1F833AE0006A419A /* APIClient.swift */; };
+		E4D89DA21F833BE2006A419A /* Micropost.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D89DA11F833BE2006A419A /* Micropost.swift */; };
 		E4F700641F7A260700869BD5 /* TutorialView.xib in Resources */ = {isa = PBXBuildFile; fileRef = E4F700631F7A260700869BD5 /* TutorialView.xib */; };
 		E4F700661F7A2FBD00869BD5 /* ColorButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F700651F7A2FBD00869BD5 /* ColorButton.swift */; };
 		E4F700681F7A4BEA00869BD5 /* ProfileView.xib in Resources */ = {isa = PBXBuildFile; fileRef = E4F700671F7A4BEA00869BD5 /* ProfileView.xib */; };
 		E4F7006A1F7A4E8E00869BD5 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F700691F7A4E8E00869BD5 /* ProfileView.swift */; };
+		E4F7006C1F7B81F300869BD5 /* TutorialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F7006B1F7B81F300869BD5 /* TutorialView.swift */; };
 		E4F7006E1F7B9BB900869BD5 /* UserFeed.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E4F7006D1F7B9BB900869BD5 /* UserFeed.storyboard */; };
 		E4F700701F7B9D3E00869BD5 /* UserFeedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F7006F1F7B9D3E00869BD5 /* UserFeedViewController.swift */; };
-		E4F7006C1F7B81F300869BD5 /* TutorialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F7006B1F7B81F300869BD5 /* TutorialView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -70,15 +72,17 @@
 		AFBDE5BC1F7A268200441353 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		AFBDE5C21F7A34F000441353 /* BalloonView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BalloonView.xib; sourceTree = "<group>"; };
 		AFBDE5C41F7A390C00441353 /* BalloonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalloonView.swift; sourceTree = "<group>"; };
-		E4744B751F7CEC2D0013619D /* UserFeedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeedTests.swift; sourceTree = "<group>"; };
 		AFECFAD21F7DF321001A9A0E /* FeedUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedUITests.swift; sourceTree = "<group>"; };
+		E4744B751F7CEC2D0013619D /* UserFeedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeedTests.swift; sourceTree = "<group>"; };
+		E4D89D9F1F833AE0006A419A /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+		E4D89DA11F833BE2006A419A /* Micropost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Micropost.swift; sourceTree = "<group>"; };
 		E4F700631F7A260700869BD5 /* TutorialView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TutorialView.xib; sourceTree = "<group>"; };
 		E4F700651F7A2FBD00869BD5 /* ColorButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorButton.swift; sourceTree = "<group>"; };
 		E4F700671F7A4BEA00869BD5 /* ProfileView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProfileView.xib; sourceTree = "<group>"; };
 		E4F700691F7A4E8E00869BD5 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		E4F7006B1F7B81F300869BD5 /* TutorialView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialView.swift; sourceTree = "<group>"; };
 		E4F7006D1F7B9BB900869BD5 /* UserFeed.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = UserFeed.storyboard; sourceTree = "<group>"; };
 		E4F7006F1F7B9D3E00869BD5 /* UserFeedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeedViewController.swift; sourceTree = "<group>"; };
-		E4F7006B1F7B81F300869BD5 /* TutorialView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -142,6 +146,7 @@
 			isa = PBXGroup;
 			children = (
 				AFBDE5B81F7A265500441353 /* .gitkeep */,
+				E4D89D9F1F833AE0006A419A /* APIClient.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -150,6 +155,7 @@
 			isa = PBXGroup;
 			children = (
 				AFBDE5BA1F7A267300441353 /* .gitkeep */,
+				E4D89DA11F833BE2006A419A /* Micropost.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -410,10 +416,12 @@
 				E4F7006A1F7A4E8E00869BD5 /* ProfileView.swift in Sources */,
 				E4F700701F7B9D3E00869BD5 /* UserFeedViewController.swift in Sources */,
 				AFBDE5C51F7A390C00441353 /* BalloonView.swift in Sources */,
+				E4D89DA01F833AE1006A419A /* APIClient.swift in Sources */,
 				E4F7006C1F7B81F300869BD5 /* TutorialView.swift in Sources */,
 				E4F700661F7A2FBD00869BD5 /* ColorButton.swift in Sources */,
 				AF161EF11F78A6FF00B2DD73 /* FeedViewController.swift in Sources */,
 				AF161EEF1F78A6FF00B2DD73 /* AppDelegate.swift in Sources */,
+				E4D89DA21F833BE2006A419A /* Micropost.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/piyopiyo.xcodeproj/project.pbxproj
+++ b/piyopiyo.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		E4744B761F7CEC2D0013619D /* UserFeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4744B751F7CEC2D0013619D /* UserFeedTests.swift */; };
 		E4D89DA01F833AE1006A419A /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D89D9F1F833AE0006A419A /* APIClient.swift */; };
 		E4D89DA21F833BE2006A419A /* Micropost.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D89DA11F833BE2006A419A /* Micropost.swift */; };
+		E4D89DA41F8383CD006A419A /* MicropostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D89DA31F8383CD006A419A /* MicropostTests.swift */; };
 		E4F700641F7A260700869BD5 /* TutorialView.xib in Resources */ = {isa = PBXBuildFile; fileRef = E4F700631F7A260700869BD5 /* TutorialView.xib */; };
 		E4F700661F7A2FBD00869BD5 /* ColorButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F700651F7A2FBD00869BD5 /* ColorButton.swift */; };
 		E4F700681F7A4BEA00869BD5 /* ProfileView.xib in Resources */ = {isa = PBXBuildFile; fileRef = E4F700671F7A4BEA00869BD5 /* ProfileView.xib */; };
@@ -76,6 +77,7 @@
 		E4744B751F7CEC2D0013619D /* UserFeedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeedTests.swift; sourceTree = "<group>"; };
 		E4D89D9F1F833AE0006A419A /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		E4D89DA11F833BE2006A419A /* Micropost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Micropost.swift; sourceTree = "<group>"; };
+		E4D89DA31F8383CD006A419A /* MicropostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicropostTests.swift; sourceTree = "<group>"; };
 		E4F700631F7A260700869BD5 /* TutorialView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TutorialView.xib; sourceTree = "<group>"; };
 		E4F700651F7A2FBD00869BD5 /* ColorButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorButton.swift; sourceTree = "<group>"; };
 		E4F700671F7A4BEA00869BD5 /* ProfileView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProfileView.xib; sourceTree = "<group>"; };
@@ -238,6 +240,7 @@
 			children = (
 				AF161F031F78A6FF00B2DD73 /* piyopiyoTests.swift */,
 				AF161F051F78A6FF00B2DD73 /* Info.plist */,
+				E4D89DA31F8383CD006A419A /* MicropostTests.swift */,
 			);
 			path = piyopiyoTests;
 			sourceTree = "<group>";
@@ -430,6 +433,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AF161F041F78A6FF00B2DD73 /* piyopiyoTests.swift in Sources */,
+				E4D89DA41F8383CD006A419A /* MicropostTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -33,6 +33,11 @@ class FeedViewController: UIViewController, TutorialDelegate {
             tutorialView.delegate = self
             addTutorial(tutorialView: tutorialView)
         }
+        
+        Micropost.fetchRandomMicroposts() { microposts in
+            print("---------------------------")
+            dump(microposts)
+        }
     }
 
     private func addTutorial(tutorialView: TutorialView?) {

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -33,11 +33,7 @@ class FeedViewController: UIViewController, TutorialDelegate {
             tutorialView.delegate = self
             addTutorial(tutorialView: tutorialView)
         }
-        
-        Micropost.fetchRandomMicroposts() { microposts in
-            print("---------------------------")
-            dump(microposts)
-        }
+
     }
 
     private func addTutorial(tutorialView: TutorialView?) {

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -33,7 +33,6 @@ class FeedViewController: UIViewController, TutorialDelegate {
             tutorialView.delegate = self
             addTutorial(tutorialView: tutorialView)
         }
-
     }
 
     private func addTutorial(tutorialView: TutorialView?) {

--- a/piyopiyo/Classes/Helpers/APIClient.swift
+++ b/piyopiyo/Classes/Helpers/APIClient.swift
@@ -1,0 +1,51 @@
+//
+//  APIClient.swift
+//  piyopiyo
+//
+//  Created by shohei.ogata on 2017/10/03.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import Foundation
+
+import Foundation
+import Alamofire
+import SwiftyJSON
+
+class APIClient {
+    static private let baseUrl = "http://shizuna.xyz"
+    
+    static func request(endpoint: Endpoint, handler: @escaping (_ json: JSON) -> Void) {
+        let method = endpoint.method()
+        let url = fullURL(endpoint: endpoint)
+        
+        Alamofire.request(url, method: method).validate(statusCode: 200...299).responseJSON { response in
+            switch response.result {
+            case .success(let value):
+                handler(JSON(value))
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+    
+    static private func fullURL(endpoint: Endpoint) -> String {
+        return baseUrl + endpoint.path()
+    }
+}
+
+enum Endpoint {
+    case randomMicroposts
+    
+    func method() -> HTTPMethod {
+        switch self {
+        case .randomMicroposts: return .get
+        }
+    }
+    
+    func path() -> String {
+        switch self {
+        case .randomMicroposts: return "/api/random"
+        }
+    }
+}

--- a/piyopiyo/Classes/Helpers/APIClient.swift
+++ b/piyopiyo/Classes/Helpers/APIClient.swift
@@ -22,10 +22,9 @@ class APIClient {
         Alamofire.request(url, method: method).validate(statusCode: 200...299).responseJSON { response in
             switch response.result {
             case .success(let value):
-                print(value)
                 handler(JSON(value))
             case .failure(let error):
-                print(error)
+                handler([])
             }
         }
     }
@@ -33,10 +32,6 @@ class APIClient {
     static private func fullURL(endpoint: Endpoint) -> String {
         return baseUrl + endpoint.path()
     }
-}
-
-enum APIError: Error {
-    case server(Int)
 }
 
 enum Endpoint {

--- a/piyopiyo/Classes/Helpers/APIClient.swift
+++ b/piyopiyo/Classes/Helpers/APIClient.swift
@@ -22,6 +22,7 @@ class APIClient {
         Alamofire.request(url, method: method).validate(statusCode: 200...299).responseJSON { response in
             switch response.result {
             case .success(let value):
+                print(value)
                 handler(JSON(value))
             case .failure(let error):
                 print(error)
@@ -32,6 +33,10 @@ class APIClient {
     static private func fullURL(endpoint: Endpoint) -> String {
         return baseUrl + endpoint.path()
     }
+}
+
+enum APIError: Error {
+    case server(Int)
 }
 
 enum Endpoint {

--- a/piyopiyo/Classes/Helpers/APIClient.swift
+++ b/piyopiyo/Classes/Helpers/APIClient.swift
@@ -7,8 +7,6 @@
 //
 
 import Foundation
-
-import Foundation
 import Alamofire
 import SwiftyJSON
 

--- a/piyopiyo/Classes/Models/Micropost.swift
+++ b/piyopiyo/Classes/Models/Micropost.swift
@@ -12,18 +12,18 @@ class Micropost {
     var userID: Int
     var content: String
     
-    init(content: String, userID: int) {
+    init(content: String, userID: Int) {
         self.content = content
         self.userID = userID
     }
     
     static func fetchRandomMicroposts(handler: @escaping ((Array<Micropost>) -> Void)) {
         APIClient.request(endpoint: Endpoint.randomMicroposts) { json in
-            let randomMicroposts = json["data"].arrayValue.map {
-                Micropost(content: $0["content"].stringValue, id: $0["id"].intValue)
+            let randomMicroposts = json["microposts"].arrayValue.map {
+                Micropost(content: $0["content"].stringValue, userID: $0["id"].intValue)
             }
             
-            handler(RandomMicroposts)
+            handler(randomMicroposts)
         }
     }
 }

--- a/piyopiyo/Classes/Models/Micropost.swift
+++ b/piyopiyo/Classes/Models/Micropost.swift
@@ -1,0 +1,29 @@
+//
+//  RandomMicroposts.swift
+//  piyopiyo
+//
+//  Created by shohei.ogata on 2017/10/03.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import Foundation
+
+class Micropost {
+    var userID: Int
+    var content: String
+    
+    init(content: String, userID: int) {
+        self.content = content
+        self.userID = userID
+    }
+    
+    static func fetchRandomMicroposts(handler: @escaping ((Array<Micropost>) -> Void)) {
+        APIClient.request(endpoint: Endpoint.randomMicroposts) { json in
+            let randomMicroposts = json["data"].arrayValue.map {
+                Micropost(content: $0["content"].stringValue, id: $0["id"].intValue)
+            }
+            
+            handler(RandomMicroposts)
+        }
+    }
+}

--- a/piyopiyo/Info.plist
+++ b/piyopiyo/Info.plist
@@ -41,5 +41,16 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>shizuna.xyz</key>
+			<dict>
+				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/piyopiyoTests/MicropostTests.swift
+++ b/piyopiyoTests/MicropostTests.swift
@@ -1,0 +1,28 @@
+//
+//  ApiClientTests.swift
+//  piyopiyoTests
+//
+//  Created by shohei.ogata on 2017/10/03.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import XCTest
+@testable import piyopiyo
+
+class MicropostTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testFatchRandomMicroposts() {
+        Micropost.fetchRandomMicroposts() { micropost in
+            XCTAssertEqual(micropost.count, 10)
+        }
+    }
+    
+}


### PR DESCRIPTION
### 何を解決するのか
- ランダムなMicropostを取得するAPIエンドポイントにアクセスする
    - １０件のランダムMicropostを取得する

### 詳細
- #29 （作業ログ）

### 期日
ユーザーモデルに手をつけ始める手前まで（ちょっと急ぎめ）

### レビューポイント
- piyopiyo/Classes/Helpers/APIClient.swift
    - ここにAPI通信周りを集約する方針
- piyopiyo/Classes/Models/Micropost.swift
    - Micropostモデルとして、ユーザーIDとつぶやき内容を保持
- piyopiyoTests/MicropostTests.swift
    - Micropostモデルを用いてランダムなつぶやきを１０件取得できるかどうかをテスト

### レビュアー
@shizunaito @Asuforce 
