### PR TITLE
アニメーションをUIView.animateからUIViewPropertyAnimatorに変更

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class FeedViewController: UIViewController, TutorialDelegate {
-    
+
     static let screenSize = UIScreen.main.bounds.size
     static let hiyokoHeight: CGFloat = 100.0
     
@@ -23,9 +23,8 @@ class FeedViewController: UIViewController, TutorialDelegate {
     static let initialBalloonY = screenSize.height - bottomMargin
 
     private let balloonView = BalloonView(frame: CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0))
-
     private var tutorialView: TutorialView?
- 
+
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class FeedViewController: UIViewController, TutorialDelegate {
-
+    
     static let screenSize = UIScreen.main.bounds.size
     static let hiyokoHeight: CGFloat = 100.0
     
@@ -23,8 +23,9 @@ class FeedViewController: UIViewController, TutorialDelegate {
     static let initialBalloonY = screenSize.height - bottomMargin
 
     private let balloonView = BalloonView(frame: CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0))
-    private var tutorialView: TutorialView?
 
+    private var tutorialView: TutorialView?
+ 
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -42,7 +43,6 @@ class FeedViewController: UIViewController, TutorialDelegate {
 
         view.addSubview(tutorialView)
     }
-
     
     func startButtonDidTap() {
         view.addSubview(balloonView)
@@ -50,22 +50,34 @@ class FeedViewController: UIViewController, TutorialDelegate {
     }
 
     private func animateBalloon() {
-        UIView.animate(withDuration: 1, delay: 0.5, animations: {
-            let originBalloonX = FeedViewController.initialBalloonX - FeedViewController.balloonWidth
-            let originBalloonY = FeedViewController.initialBalloonY - FeedViewController.balloonHeight
-            
-            self.balloonView.frame = CGRect(x: originBalloonX, y: originBalloonY, width: FeedViewController.balloonWidth, height: FeedViewController.balloonHeight)
+        let originBalloonX = FeedViewController.initialBalloonX - FeedViewController.balloonWidth
+        let originBalloonY = FeedViewController.initialBalloonY - FeedViewController.balloonHeight
+
+        self.balloonView.frame = CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0)
+        self.balloonView.layoutIfNeeded()
+
+        let animator = UIViewPropertyAnimator(duration: 5.0, curve: .easeIn, animations: nil)
+
+        let inflateAnimator = UIViewPropertyAnimator(duration: 1.0, curve: .linear) {
+            self.balloonView.frame = CGRect(x: originBalloonX, y: originBalloonY, width: FeedViewController.balloonWidth - 0.1, height: FeedViewController.balloonHeight - 0.1)
             self.balloonView.layoutIfNeeded()
-        }) { _ in
-            UIView.animate(withDuration: 5, delay: 0.5, animations: {
-                self.balloonView.frame.origin.y = -FeedViewController.balloonHeight
-                self.balloonView.layoutIfNeeded()
-            }) { _ in
-                self.balloonView.frame = CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0)
-                self.balloonView.layoutIfNeeded()
-                self.animateBalloon()
-            }
         }
+
+        func completeInflationAnimator() {
+            self.balloonView.frame.size = CGSize(width: FeedViewController.balloonWidth, height: FeedViewController.balloonHeight)
+            self.balloonView.layoutIfNeeded()
+        }
+
+        func flyAnimator() {
+            self.balloonView.frame.origin.y = -FeedViewController.balloonHeight
+            self.balloonView.layoutIfNeeded()
+        }
+
+        animator.addAnimations(inflateAnimator.startAnimation)
+        animator.addAnimations(completeInflationAnimator, delayFactor: 0.2)
+        animator.addAnimations(flyAnimator, delayFactor: 0.2)
+
+        animator.startAnimation()
     }
 
     override func didReceiveMemoryWarning() {

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -77,6 +77,10 @@ class FeedViewController: UIViewController, TutorialDelegate {
         animator.addAnimations(completeInflationAnimator, delayFactor: 0.2)
         animator.addAnimations(flyAnimator, delayFactor: 0.2)
 
+        animator.addCompletion {_ in
+            self.animateBalloon()
+        }
+
         animator.startAnimation()
     }
 


### PR DESCRIPTION
### 何を解決するのか
 `UIView.animate`を使っていたが、そうするとBalloonViewを画面外に出すアニメーション中にタップできなかった。
なので、`UIViewPropertyAnimator`を使うように変更して、BalloonViewがどの位置にいてもタップできるようにする。

#### UI
<img width="378" alt="2017-09-28 14 40 40" src="https://user-images.githubusercontent.com/14357415/31158885-f51f21d8-a8ff-11e7-9db5-9f9d7e33f0d5.gif">

### 詳細
作業ログ： #28 

大枠となるアニメーションを定義し、その中で以下の通りに動くようにアニメーションを追加している。
- 想定より0.1point小さいサイズまで膨らむ
- 1秒後、想定サイズまで膨らませながら飛ばす
  - 飛ばす（y座標を変える）アニメーションのみ行うとtapが効かなくなるため

### 期日
Feed -> Profileの画面遷移PRの前まで

### レビューポイント
- `FeedViewController.swift`：アニメーション定義
  - UIViewPropertyAnimatorで5秒間のアニメーション`animator`を定義
  - 1秒間でBalloonViewを **想定サイズより0.1point小さく** 膨らませるアニメーション`inflateAnimator`を定義
  - BalloonViewを想定サイズまで膨らませる関数`completeInflationAnimator`を定義
  - BalloonViewを飛ばす関数`flyAnimator`を定義
  - `inflateAnimator`をanimatorに追加
  - `completeInflationAnimator`と`flyAnimator`を **delayFactor 0.2** で`animator`に追加

### レビュアー
@piyoppi @Asuforce 