### PR TITLE
BalloonViewタップでProfileを表示

### DIFF
--- a/piyopiyo.xcodeproj/project.pbxproj
+++ b/piyopiyo.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		AF087D8F1F78E3DB006C6BAF /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF087D8D1F78E3DB006C6BAF /* Alamofire.framework */; };
 		AF087D9A1F790BA5006C6BAF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AF087D981F790B2B006C6BAF /* LaunchScreen.storyboard */; };
 		AF087D9B1F790BA5006C6BAF /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AF087D991F790B2B006C6BAF /* Main.storyboard */; };
+		AF113E2A1F8609070026921A /* ColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF113E291F8609070026921A /* ColorPalette.swift */; };
 		AF161EEF1F78A6FF00B2DD73 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF161EEE1F78A6FF00B2DD73 /* AppDelegate.swift */; };
 		AF161EF11F78A6FF00B2DD73 /* FeedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF161EF01F78A6FF00B2DD73 /* FeedViewController.swift */; };
 		AF161EF61F78A6FF00B2DD73 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AF161EF51F78A6FF00B2DD73 /* Assets.xcassets */; };
@@ -21,7 +22,6 @@
 		AFBDE5BD1F7A268200441353 /* .gitkeep in Resources */ = {isa = PBXBuildFile; fileRef = AFBDE5BC1F7A268200441353 /* .gitkeep */; };
 		AFBDE5C31F7A34F000441353 /* BalloonView.xib in Resources */ = {isa = PBXBuildFile; fileRef = AFBDE5C21F7A34F000441353 /* BalloonView.xib */; };
 		AFBDE5C51F7A390C00441353 /* BalloonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBDE5C41F7A390C00441353 /* BalloonView.swift */; };
-		AFE82D701F84B6E80009EFD2 /* ColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE82D6F1F84B6E80009EFD2 /* ColorPalette.swift */; };
 		AFECFAD31F7DF321001A9A0E /* FeedUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFECFAD21F7DF321001A9A0E /* FeedUITests.swift */; };
 		E4744B761F7CEC2D0013619D /* UserFeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4744B751F7CEC2D0013619D /* UserFeedTests.swift */; };
 		E4AE01DB1F84A761002A1446 /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AE01DA1F84A761002A1446 /* UserProfile.swift */; };
@@ -60,6 +60,7 @@
 		AF087D8D1F78E3DB006C6BAF /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
 		AF087D981F790B2B006C6BAF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		AF087D991F790B2B006C6BAF /* Main.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+		AF113E291F8609070026921A /* ColorPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPalette.swift; sourceTree = "<group>"; };
 		AF161EEB1F78A6FF00B2DD73 /* piyopiyo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = piyopiyo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF161EEE1F78A6FF00B2DD73 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AF161EF01F78A6FF00B2DD73 /* FeedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewController.swift; sourceTree = "<group>"; };
@@ -76,7 +77,6 @@
 		AFBDE5BC1F7A268200441353 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		AFBDE5C21F7A34F000441353 /* BalloonView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BalloonView.xib; sourceTree = "<group>"; };
 		AFBDE5C41F7A390C00441353 /* BalloonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalloonView.swift; sourceTree = "<group>"; };
-		AFE82D6F1F84B6E80009EFD2 /* ColorPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPalette.swift; sourceTree = "<group>"; };
 		AFECFAD21F7DF321001A9A0E /* FeedUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedUITests.swift; sourceTree = "<group>"; };
 		E4744B751F7CEC2D0013619D /* UserFeedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeedTests.swift; sourceTree = "<group>"; };
 		E4AE01DA1F84A761002A1446 /* UserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
@@ -155,7 +155,7 @@
 			children = (
 				AFBDE5B81F7A265500441353 /* .gitkeep */,
 				E4D89D9F1F833AE0006A419A /* APIClient.swift */,
-				AFE82D6F1F84B6E80009EFD2 /* ColorPalette.swift */,
+				AF113E291F8609070026921A /* ColorPalette.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -430,12 +430,12 @@
 				AFBDE5C51F7A390C00441353 /* BalloonView.swift in Sources */,
 				E4D89DA01F833AE1006A419A /* APIClient.swift in Sources */,
 				E4F7006C1F7B81F300869BD5 /* TutorialView.swift in Sources */,
-				AFE82D701F84B6E80009EFD2 /* ColorPalette.swift in Sources */,
 				E4F700661F7A2FBD00869BD5 /* ColorButton.swift in Sources */,
 				AF161EF11F78A6FF00B2DD73 /* FeedViewController.swift in Sources */,
 				AF161EEF1F78A6FF00B2DD73 /* AppDelegate.swift in Sources */,
 				E4AE01DB1F84A761002A1446 /* UserProfile.swift in Sources */,
 				E4D89DA21F833BE2006A419A /* Micropost.swift in Sources */,
+				AF113E2A1F8609070026921A /* ColorPalette.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/piyopiyo.xcodeproj/project.pbxproj
+++ b/piyopiyo.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		AFBDE5BD1F7A268200441353 /* .gitkeep in Resources */ = {isa = PBXBuildFile; fileRef = AFBDE5BC1F7A268200441353 /* .gitkeep */; };
 		AFBDE5C31F7A34F000441353 /* BalloonView.xib in Resources */ = {isa = PBXBuildFile; fileRef = AFBDE5C21F7A34F000441353 /* BalloonView.xib */; };
 		AFBDE5C51F7A390C00441353 /* BalloonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBDE5C41F7A390C00441353 /* BalloonView.swift */; };
+		AFE82D701F84B6E80009EFD2 /* ColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE82D6F1F84B6E80009EFD2 /* ColorPalette.swift */; };
 		AFECFAD31F7DF321001A9A0E /* FeedUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFECFAD21F7DF321001A9A0E /* FeedUITests.swift */; };
 		E4744B761F7CEC2D0013619D /* UserFeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4744B751F7CEC2D0013619D /* UserFeedTests.swift */; };
 		E4AE01DB1F84A761002A1446 /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AE01DA1F84A761002A1446 /* UserProfile.swift */; };
@@ -75,6 +76,7 @@
 		AFBDE5BC1F7A268200441353 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		AFBDE5C21F7A34F000441353 /* BalloonView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BalloonView.xib; sourceTree = "<group>"; };
 		AFBDE5C41F7A390C00441353 /* BalloonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalloonView.swift; sourceTree = "<group>"; };
+		AFE82D6F1F84B6E80009EFD2 /* ColorPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPalette.swift; sourceTree = "<group>"; };
 		AFECFAD21F7DF321001A9A0E /* FeedUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedUITests.swift; sourceTree = "<group>"; };
 		E4744B751F7CEC2D0013619D /* UserFeedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeedTests.swift; sourceTree = "<group>"; };
 		E4AE01DA1F84A761002A1446 /* UserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
@@ -153,6 +155,7 @@
 			children = (
 				AFBDE5B81F7A265500441353 /* .gitkeep */,
 				E4D89D9F1F833AE0006A419A /* APIClient.swift */,
+				AFE82D6F1F84B6E80009EFD2 /* ColorPalette.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -427,6 +430,7 @@
 				AFBDE5C51F7A390C00441353 /* BalloonView.swift in Sources */,
 				E4D89DA01F833AE1006A419A /* APIClient.swift in Sources */,
 				E4F7006C1F7B81F300869BD5 /* TutorialView.swift in Sources */,
+				AFE82D701F84B6E80009EFD2 /* ColorPalette.swift in Sources */,
 				E4F700661F7A2FBD00869BD5 /* ColorButton.swift in Sources */,
 				AF161EF11F78A6FF00B2DD73 /* FeedViewController.swift in Sources */,
 				AF161EEF1F78A6FF00B2DD73 /* AppDelegate.swift in Sources */,

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class FeedViewController: UIViewController, TutorialDelegate {
+class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegate {
 
     static let screenSize = UIScreen.main.bounds.size
     static let hiyokoHeight: CGFloat = 100.0
@@ -26,16 +26,26 @@ class FeedViewController: UIViewController, TutorialDelegate {
     
     private var balloonCycleCount: Int = 0
     private var balloonViews = [BalloonView]()
+    
+    static let originalProfileSize = CGSize(width: 280, height: 500)
+    static let originalProfilePoint = CGPoint(x: (screenSize.width - originalProfileSize.width)/2, y: (screenSize.height - originalProfileSize.height)/2)
+
     private var tutorialView: TutorialView?
+    private let profileView = ProfileView(frame: CGRect(origin: FeedViewController.originalProfilePoint, size: FeedViewController.originalProfileSize))
+    private var profileBackgroundView = UIView(frame: CGRect(origin: CGPoint.zero, size: FeedViewController.screenSize))
+
+    private let animator = UIViewPropertyAnimator(duration: 5.0, curve: .easeIn, animations: nil)
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        balloonView.delegate = self
         tutorialView = TutorialView(frame: self.view.frame)
         if let tutorialView = tutorialView {
             tutorialView.delegate = self
             addTutorial(tutorialView: tutorialView)
         }
+        profileBackgroundView.backgroundColor = ColorPalette.profileBackgroundColor
     }
 
     private func addTutorial(tutorialView: TutorialView?) {
@@ -74,8 +84,6 @@ class FeedViewController: UIViewController, TutorialDelegate {
         balloonView.frame = CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0)
         balloonView.layoutIfNeeded()
 
-        let animator = UIViewPropertyAnimator(duration: 5.0, curve: .easeIn, animations: nil)
-
         let inflateAnimator = UIViewPropertyAnimator(duration: 1.0, curve: .linear) {
             balloonView.frame = CGRect(x: originBalloonX, y: originBalloonY, width: FeedViewController.balloonWidth - 0.1, height: FeedViewController.balloonHeight - 0.1)
             balloonView.layoutIfNeeded()
@@ -105,6 +113,12 @@ class FeedViewController: UIViewController, TutorialDelegate {
         }
 
         animator.startAnimation()
+    }
+
+    func textViewDidTap() {
+        animator.pauseAnimation()
+        view.addSubview(profileBackgroundView)
+        view.addSubview(profileView)
     }
 
     override func didReceiveMemoryWarning() {

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -37,7 +37,6 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        balloonView.delegate = self
         tutorialView = TutorialView(frame: self.view.frame)
         if let tutorialView = tutorialView {
             tutorialView.delegate = self
@@ -60,6 +59,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             let balloonView = BalloonView(frame: CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0))
             balloonView.textView.accessibilityIdentifier = "balloonText\(i)"
             balloonViews += [balloonView]
+            balloonView.delegate = self
             view.addSubview(balloonView)
         }
     }

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -119,6 +119,8 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     func textViewDidTap() {
         view.addSubview(profileBackgroundView)
         view.addSubview(profileView)
+        profileBackgroundView.layer.zPosition = CGFloat(FeedViewController.balloonCount + 1)
+        profileView.layer.zPosition = CGFloat(FeedViewController.balloonCount + 2)
     }
 
     func closeButtonDidTap() {

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -27,7 +27,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     private var balloonCycleCount: Int = 0
     private var balloonViews = [BalloonView]()
     
-    static let originalProfileSize = CGSize(width: 280, height: 500)
+    static let originalProfileSize = CGSize(width: 300, height: 533.5)
     static let originalProfilePoint = CGPoint(x: (screenSize.width - originalProfileSize.width)/2, y: (screenSize.height - originalProfileSize.height)/2)
 
     private var tutorialView: TutorialView?

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegate {
+class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegate , ProfileViewDelegate {
 
     static let screenSize = UIScreen.main.bounds.size
     static let hiyokoHeight: CGFloat = 100.0
@@ -34,8 +34,6 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     private let profileView = ProfileView(frame: CGRect(origin: FeedViewController.originalProfilePoint, size: FeedViewController.originalProfileSize))
     private var profileBackgroundView = UIView(frame: CGRect(origin: CGPoint.zero, size: FeedViewController.screenSize))
 
-    private let animator = UIViewPropertyAnimator(duration: 5.0, curve: .easeIn, animations: nil)
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -45,6 +43,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             tutorialView.delegate = self
             addTutorial(tutorialView: tutorialView)
         }
+        profileView.delegate = self
         profileBackgroundView.backgroundColor = ColorPalette.profileBackgroundColor
     }
 
@@ -84,6 +83,8 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         balloonView.frame = CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0)
         balloonView.layoutIfNeeded()
 
+        let animator = UIViewPropertyAnimator(duration: 5.0, curve: .easeIn, animations: nil)
+
         let inflateAnimator = UIViewPropertyAnimator(duration: 1.0, curve: .linear) {
             balloonView.frame = CGRect(x: originBalloonX, y: originBalloonY, width: FeedViewController.balloonWidth - 0.1, height: FeedViewController.balloonHeight - 0.1)
             balloonView.layoutIfNeeded()
@@ -116,9 +117,12 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     }
 
     func textViewDidTap() {
-        animator.pauseAnimation()
         view.addSubview(profileBackgroundView)
         view.addSubview(profileView)
+    }
+
+    func closeButtonDidTap() {
+        profileBackgroundView.removeFromSuperview()
     }
 
     override func didReceiveMemoryWarning() {

--- a/piyopiyo/Classes/Helpers/ColorPalette.swift
+++ b/piyopiyo/Classes/Helpers/ColorPalette.swift
@@ -1,0 +1,13 @@
+//
+//  ColorPalette.swift
+//  piyopiyo
+//
+//  Created by shizuna.ito on 2017/10/04.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import UIKit
+
+struct ColorPalette {
+    static let profileBackgroundColor = UIColor(red: 0/255, green: 0/255, blue: 0/255, alpha: 0.5)
+}

--- a/piyopiyo/Classes/Views/BalloonView.swift
+++ b/piyopiyo/Classes/Views/BalloonView.swift
@@ -8,8 +8,13 @@
 
 import UIKit
 
+protocol BalloonViewDelegate: class {
+    func textViewDidTap()
+}
+
 class BalloonView: UIView {
     
+    weak var delegate: BalloonViewDelegate?
     @IBOutlet weak var textView: UITextView!
     
     override init(frame: CGRect) {
@@ -28,5 +33,9 @@ class BalloonView: UIView {
         }
         view.frame = bounds
         addSubview(view)
+    }
+
+    @IBAction func tap(_ sender: UIGestureRecognizer) {
+        delegate?.textViewDidTap()
     }
 }

--- a/piyopiyo/Classes/Views/ProfileView.swift
+++ b/piyopiyo/Classes/Views/ProfileView.swift
@@ -8,8 +8,13 @@
 
 import UIKit
 
+protocol ProfileViewDelegate: class {
+    func closeButtonDidTap()
+}
+
 class ProfileView: UIView {
     
+    weak var delegate: ProfileViewDelegate?
     @IBOutlet weak var profileImageView: UIImageView! {
         didSet {
             profileImageView.layer.cornerRadius = profileImageView.bounds.width / 2
@@ -38,4 +43,8 @@ class ProfileView: UIView {
         addSubview(view)
     }
     
+    @IBAction func closeButtonDidTap(_ sender: UIButton) {
+        delegate?.closeButtonDidTap()
+        removeFromSuperview()
+    }
 }

--- a/piyopiyo/Xibs/BalloonView.xib
+++ b/piyopiyo/Xibs/BalloonView.xib
@@ -25,6 +25,7 @@
                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" usesAttributedText="YES" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f9c-EM-a9B">
                     <rect key="frame" x="20" y="13" width="223" height="111"/>
                     <accessibility key="accessibilityConfiguration" identifier="commentLabel"/>
+                    <gestureRecognizers/>
                     <attributedString key="attributedText">
                         <fragment content="今日はいい天気だなあ。朝食も美味しかったなあ。">
                             <attributes>
@@ -34,8 +35,12 @@
                         </fragment>
                     </attributedString>
                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                    <connections>
+                        <outletCollection property="gestureRecognizers" destination="keT-wI-qiX" appends="YES" id="whQ-1u-yCa"/>
+                    </connections>
                 </textView>
             </subviews>
+            <gestureRecognizers/>
             <constraints>
                 <constraint firstItem="f9c-EM-a9B" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="13" id="63S-X3-ukH"/>
                 <constraint firstItem="2em-0u-ba3" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="9Za-P0-tJc"/>
@@ -50,6 +55,11 @@
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="43" y="-164"/>
         </view>
+        <tapGestureRecognizer cancelsTouchesInView="NO" id="keT-wI-qiX">
+            <connections>
+                <action selector="tap:" destination="-1" id="caB-s7-BdX"/>
+            </connections>
+        </tapGestureRecognizer>
     </objects>
     <resources>
         <image name="balloon" width="800" height="499"/>

--- a/piyopiyo/Xibs/ProfileView.xib
+++ b/piyopiyo/Xibs/ProfileView.xib
@@ -16,29 +16,40 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="300" height="533.5"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="unknown_avatar" translatesAutoresizingMaskIntoConstraints="NO" id="tXe-ji-jIM">
-                    <rect key="frame" x="107" y="96" width="160" height="160"/>
+                    <rect key="frame" x="86" y="81" width="128" height="128"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="160" id="TeQ-yM-Efc"/>
-                        <constraint firstAttribute="height" constant="160" id="iNF-Jr-Vd1"/>
+                        <constraint firstAttribute="width" constant="128" id="TeQ-yM-Efc"/>
+                        <constraint firstAttribute="height" constant="128" id="iNF-Jr-Vd1"/>
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ユーザー名" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pkk-DH-BKU">
-                    <rect key="frame" x="99" y="281" width="176.5" height="42"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="35"/>
+                    <rect key="frame" x="79.5" y="229" width="142" height="33.5"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="28"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nFI-7O-MLE" customClass="ColorButton" customModule="piyopiyo" customModuleProvider="target">
-                    <rect key="frame" x="54" y="497" width="266" height="71"/>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TWs-qF-ZK2">
+                    <rect key="frame" x="243" y="33" width="44" height="44"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="266" id="MsV-te-bcF"/>
-                        <constraint firstAttribute="height" constant="71" id="aH4-do-5Ew"/>
+                        <constraint firstAttribute="height" constant="44" id="URm-ve-m85"/>
+                        <constraint firstAttribute="width" constant="44" id="s1S-6S-i4B"/>
                     </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="26"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="70"/>
+                    <state key="normal" title="×">
+                        <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nFI-7O-MLE" customClass="ColorButton" customModule="piyopiyo" customModuleProvider="target">
+                    <rect key="frame" x="44" y="398" width="213" height="57"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="213" id="012-Di-mB5"/>
+                        <constraint firstAttribute="height" constant="57" id="HPf-C9-Wo2"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="21"/>
                     <state key="normal" title="ほかのつぶやき">
                         <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <color key="titleShadowColor" red="0.46144349093264247" green="0.32019209552247407" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -52,34 +63,24 @@
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                 </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TWs-qF-ZK2">
-                    <rect key="frame" x="304" y="36" width="55" height="55"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="55" id="URm-ve-m85"/>
-                        <constraint firstAttribute="width" constant="55" id="s1S-6S-i4B"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="70"/>
-                    <state key="normal" title="×">
-                        <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
-                    </state>
-                </button>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <color key="tintColor" cocoaTouchSystemColor="darkTextColor"/>
             <constraints>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="TWs-qF-ZK2" secondAttribute="trailing" constant="16" id="4te-q9-No5"/>
-                <constraint firstItem="tXe-ji-jIM" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="76" id="9z3-ZN-APF"/>
-                <constraint firstItem="TWs-qF-ZK2" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="16" id="Flk-Cf-fc2"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="TWs-qF-ZK2" secondAttribute="trailing" constant="13" id="4te-q9-No5"/>
+                <constraint firstItem="tXe-ji-jIM" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="61" id="9z3-ZN-APF"/>
+                <constraint firstItem="TWs-qF-ZK2" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="13" id="Flk-Cf-fc2"/>
                 <constraint firstItem="Pkk-DH-BKU" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="RrI-p7-Ltn"/>
                 <constraint firstItem="nFI-7O-MLE" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" id="X4V-R5-Hl5"/>
-                <constraint firstItem="Pkk-DH-BKU" firstAttribute="top" secondItem="tXe-ji-jIM" secondAttribute="bottom" constant="25" id="YmC-x4-A6U"/>
+                <constraint firstItem="Pkk-DH-BKU" firstAttribute="top" secondItem="tXe-ji-jIM" secondAttribute="bottom" constant="20" id="YmC-x4-A6U"/>
                 <constraint firstItem="tXe-ji-jIM" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="e6Y-5G-FcN"/>
                 <constraint firstItem="nFI-7O-MLE" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="eMn-px-NZa"/>
                 <constraint firstItem="tXe-ji-jIM" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="geF-oV-0mw"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="nFI-7O-MLE" secondAttribute="bottom" constant="99" id="v9v-pF-T7J"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="nFI-7O-MLE" secondAttribute="bottom" constant="79" id="v9v-pF-T7J"/>
             </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
-            <point key="canvasLocation" x="25.5" y="52.5"/>
+            <point key="canvasLocation" x="25" y="52"/>
         </view>
     </objects>
     <resources>

--- a/piyopiyo/Xibs/ProfileView.xib
+++ b/piyopiyo/Xibs/ProfileView.xib
@@ -42,6 +42,9 @@
                     <state key="normal" title="×">
                         <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                     </state>
+                    <connections>
+                        <action selector="closeButtonDidTap:" destination="-1" eventType="touchUpInside" id="4Xd-Bp-ABG"/>
+                    </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nFI-7O-MLE" customClass="ColorButton" customModule="piyopiyo" customModuleProvider="target">
                     <rect key="frame" x="44" y="398" width="213" height="57"/>


### PR DESCRIPTION
### 何を解決するのか
Feed画面とProfileViewの画面遷移ができるようにする
- BalloonViewタップ時にProfileViewを表示（FeedVCのサブビューに追加）
- ProfileViewの『×』ボタンタップ時にProfileViewを閉じる（FeedVCのサブビューから削除）

#### UI
<img width="378" alt="2017-09-28 14 40 40" src="https://user-images.githubusercontent.com/14357415/31214038-62aa5ecc-a9e4-11e7-9e60-4bbad0ded875.gif">

### 詳細
作業ログ #28 

### 期日
ProfileView -> WebViewの遷移実装まで（なるべく早め）

### レビューポイント
- `BalloonView.swift`：`textView`のタップアクション及びそれをFeedVCに伝えるdelegationを追加
- `ProfileView.swift`：`closeButton`のタップアクション及びそれをFeedVCに伝えるdelegationを追加
- `FeedViewController.swift`
  - 上記のdelegateprotocolに準拠
  - `textView`タップ時のProfileView表示・`closeButton`タップ時のProfileView非表示
- `ColorPalette.swift`：カラーパレットを追加

### 実機テスト
下記の操作を行ってUIをテストしてください
- [x] 吹き出しのタップ　→　ProfileViewが表示
- [x] プロフィール内の『×』ボタンのタップ　→　ProfileViewの非表示

### レビュアー
@Asuforce @piyoppi 