### PR TITLE
APIからユーザー情報を取得する処理を追加

### DIFF
--- a/piyopiyo.xcodeproj/project.pbxproj
+++ b/piyopiyo.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		AFBDE5C51F7A390C00441353 /* BalloonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBDE5C41F7A390C00441353 /* BalloonView.swift */; };
 		AFECFAD31F7DF321001A9A0E /* FeedUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFECFAD21F7DF321001A9A0E /* FeedUITests.swift */; };
 		E4744B761F7CEC2D0013619D /* UserFeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4744B751F7CEC2D0013619D /* UserFeedTests.swift */; };
+		E4AE01DB1F84A761002A1446 /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AE01DA1F84A761002A1446 /* UserProfile.swift */; };
+		E4AE01DD1F84AC46002A1446 /* UserProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AE01DC1F84AC46002A1446 /* UserProfileTests.swift */; };
 		E4D89DA01F833AE1006A419A /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D89D9F1F833AE0006A419A /* APIClient.swift */; };
 		E4D89DA21F833BE2006A419A /* Micropost.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D89DA11F833BE2006A419A /* Micropost.swift */; };
 		E4D89DA41F8383CD006A419A /* MicropostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D89DA31F8383CD006A419A /* MicropostTests.swift */; };
@@ -75,6 +77,8 @@
 		AFBDE5C41F7A390C00441353 /* BalloonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalloonView.swift; sourceTree = "<group>"; };
 		AFECFAD21F7DF321001A9A0E /* FeedUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedUITests.swift; sourceTree = "<group>"; };
 		E4744B751F7CEC2D0013619D /* UserFeedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeedTests.swift; sourceTree = "<group>"; };
+		E4AE01DA1F84A761002A1446 /* UserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
+		E4AE01DC1F84AC46002A1446 /* UserProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileTests.swift; sourceTree = "<group>"; };
 		E4D89D9F1F833AE0006A419A /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		E4D89DA11F833BE2006A419A /* Micropost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Micropost.swift; sourceTree = "<group>"; };
 		E4D89DA31F8383CD006A419A /* MicropostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicropostTests.swift; sourceTree = "<group>"; };
@@ -158,6 +162,7 @@
 			children = (
 				AFBDE5BA1F7A267300441353 /* .gitkeep */,
 				E4D89DA11F833BE2006A419A /* Micropost.swift */,
+				E4AE01DA1F84A761002A1446 /* UserProfile.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -241,6 +246,7 @@
 				AF161F031F78A6FF00B2DD73 /* piyopiyoTests.swift */,
 				AF161F051F78A6FF00B2DD73 /* Info.plist */,
 				E4D89DA31F8383CD006A419A /* MicropostTests.swift */,
+				E4AE01DC1F84AC46002A1446 /* UserProfileTests.swift */,
 			);
 			path = piyopiyoTests;
 			sourceTree = "<group>";
@@ -424,6 +430,7 @@
 				E4F700661F7A2FBD00869BD5 /* ColorButton.swift in Sources */,
 				AF161EF11F78A6FF00B2DD73 /* FeedViewController.swift in Sources */,
 				AF161EEF1F78A6FF00B2DD73 /* AppDelegate.swift in Sources */,
+				E4AE01DB1F84A761002A1446 /* UserProfile.swift in Sources */,
 				E4D89DA21F833BE2006A419A /* Micropost.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -432,6 +439,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E4AE01DD1F84AC46002A1446 /* UserProfileTests.swift in Sources */,
 				AF161F041F78A6FF00B2DD73 /* piyopiyoTests.swift in Sources */,
 				E4D89DA41F8383CD006A419A /* MicropostTests.swift in Sources */,
 			);

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -33,10 +33,6 @@ class FeedViewController: UIViewController, TutorialDelegate {
             tutorialView.delegate = self
             addTutorial(tutorialView: tutorialView)
         }
-        
-        UserProfile.fetchUserProfile(userID: 1) {profiles in
-            dump(profiles)
-        }
     }
 
     private func addTutorial(tutorialView: TutorialView?) {

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -33,6 +33,10 @@ class FeedViewController: UIViewController, TutorialDelegate {
             tutorialView.delegate = self
             addTutorial(tutorialView: tutorialView)
         }
+        
+        UserProfile.fetchUserProfile(userID: 1) {profiles in
+            dump(profiles)
+        }
     }
 
     private func addTutorial(tutorialView: TutorialView?) {

--- a/piyopiyo/Classes/Helpers/APIClient.swift
+++ b/piyopiyo/Classes/Helpers/APIClient.swift
@@ -20,10 +20,8 @@ class APIClient {
         Alamofire.request(url, method: method).validate(statusCode: 200...299).responseJSON { response in
             switch response.result {
             case .success(let value):
-                print(value)
                 handler(JSON(value))
             case .failure(let error):
-                print(error)
                 handler([])
             }
         }

--- a/piyopiyo/Classes/Helpers/APIClient.swift
+++ b/piyopiyo/Classes/Helpers/APIClient.swift
@@ -46,7 +46,7 @@ enum Endpoint {
     func path() -> String {
         switch self {
         case .randomMicroposts: return "/api/random"
-        case .userProfile(let val): return "/api/users/\(String(val))/profile"
+        case .userProfile(let value): return "/api/users/\(String(value))/profile"
         }
     }
 }

--- a/piyopiyo/Classes/Helpers/APIClient.swift
+++ b/piyopiyo/Classes/Helpers/APIClient.swift
@@ -20,8 +20,10 @@ class APIClient {
         Alamofire.request(url, method: method).validate(statusCode: 200...299).responseJSON { response in
             switch response.result {
             case .success(let value):
+                print(value)
                 handler(JSON(value))
             case .failure(let error):
+                print(error)
                 handler([])
             }
         }
@@ -34,16 +36,19 @@ class APIClient {
 
 enum Endpoint {
     case randomMicroposts
+    case userProfile(Int)
     
     func method() -> HTTPMethod {
         switch self {
         case .randomMicroposts: return .get
+        case .userProfile: return .get
         }
     }
     
     func path() -> String {
         switch self {
         case .randomMicroposts: return "/api/random"
+        case .userProfile(let val): return "/api/users/\(String(val))/profile"
         }
     }
 }

--- a/piyopiyo/Classes/Models/UserProfile.swift
+++ b/piyopiyo/Classes/Models/UserProfile.swift
@@ -1,0 +1,28 @@
+//
+//  User.swift
+//  piyopiyo
+//
+//  Created by shohei.ogata on 2017/10/04.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import Foundation
+
+class UserProfile {
+    var userID: Int
+    var name: String
+    var avatarURL: URL?
+    
+    init(name: String, userID: Int, avatarURL: URL?) {
+        self.name = name
+        self.userID = userID
+        self.avatarURL = avatarURL
+    }
+    
+    static func fetchUserProfile(userID: Int, handler: @escaping ((UserProfile) -> Void)) {
+        APIClient.request(endpoint: Endpoint.userProfile(userID)) { json in
+            let profile = UserProfile(name: json["name"].stringValue, userID: json["id"].intValue, avatarURL: URL(string: json["avatar"].stringValue))
+            handler(profile)
+        }
+    }
+}

--- a/piyopiyo/Info.plist
+++ b/piyopiyo/Info.plist
@@ -45,6 +45,11 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
 			<key>shizuna.xyz</key>
 			<dict>
 				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>

--- a/piyopiyoTests/MicropostTests.swift
+++ b/piyopiyoTests/MicropostTests.swift
@@ -20,9 +20,14 @@ class MicropostTests: XCTestCase {
     }
     
     func testFatchRandomMicroposts() {
+        let fetchRandomMicropostExpectation: XCTestExpectation? = self.expectation(description: "fetchUserProfile")
+
         Micropost.fetchRandomMicroposts() { micropost in
             XCTAssertEqual(micropost.count, 10)
+            fetchRandomMicropostExpectation?.fulfill()
         }
+        waitForExpectations(timeout: 10, handler: nil)
+
     }
     
 }

--- a/piyopiyoTests/UserProfileTests.swift
+++ b/piyopiyoTests/UserProfileTests.swift
@@ -20,9 +20,15 @@ class UserProfileTests: XCTestCase {
     }
     
     func testFetchUserProfile() {
-        UserProfile.fetchUserProfile(userID: 1) { profiles in
-            XCTAssertEqual(profiles.userID, 1)
+        let fetchUserProfileExpectation: XCTestExpectation? = self.expectation(description: "fetchUserProfile")
+
+        UserProfile.fetchUserProfile(userID: 1) { profile in
+            XCTAssertEqual(profile.userID, 1)
+            XCTAssertFalse(profile.name.isEmpty)
+            XCTAssertNotNil(profile.avatarURL)
+            fetchUserProfileExpectation?.fulfill()
         }
+        waitForExpectations(timeout: 10, handler: nil)
     }
     
 }

--- a/piyopiyoTests/UserProfileTests.swift
+++ b/piyopiyoTests/UserProfileTests.swift
@@ -1,0 +1,28 @@
+//
+//  UserProfileTests.swift
+//  piyopiyoTests
+//
+//  Created by shohei.ogata on 2017/10/04.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import XCTest
+@testable import piyopiyo
+
+class UserProfileTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testFetchUserProfile() {
+        UserProfile.fetchUserProfile(userID: 1) { profiles in
+            XCTAssertEqual(profiles.userID, 1)
+        }
+    }
+    
+}


### PR DESCRIPTION
### 何を解決するのか
- 吹き出しをタップした時に表示するユーザー情報を取得可能にした
    - `/api/users/:id/profile` にアクセスして以下の情報を取得
        - ユーザー名
        - ユーザーID
        - プロフィール画面
- ユーザー情報を格納する `UserProfile` モデルを追加
- Micropost取得周りのテストが（失敗条件でも）成功してしまう状態を修正
    - 非同期関数のテストが正しく行えるように修正

### 詳細
- （とくになし）

### 期日
- 吹き出し押下処理を追加するまで（急がない）

### レビューポイント
- piyopiyo/Classes/Helpers/APIClient.swift
    - ユーザー情報取得エンドポイントへのアクセス処理を追加
- piyopiyo/Classes/Models/UserProfile.swift
    - ユーザー情報を格納するモデルを定義
    - 必要な情報が正しく格納されそうかどうかを確認お願いします 🙇 🐤  

### レビュアー
@shizunaito @Asuforce

