### PR TITLE
複数ふきだしのアニメーション表示

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -23,6 +23,7 @@ class FeedViewController: UIViewController, TutorialDelegate {
     static let initialBalloonY = screenSize.height - bottomMargin
 
     private let balloonView = BalloonView(frame: CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0))
+    private var balloonViews = [BalloonView]()
     private var tutorialView: TutorialView?
 
     override func viewDidLoad() {
@@ -43,33 +44,50 @@ class FeedViewController: UIViewController, TutorialDelegate {
         view.addSubview(tutorialView)
     }
     
+    func makeBalloons(_ count: Int){
+        for i in 0..<count {
+            let addBalloonView = BalloonView(frame: CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY + CGFloat(i * 20), width: 10, height: 10))
+            balloonViews += [addBalloonView]
+            view.addSubview(addBalloonView)
+        }
+    }
+    
     func startButtonDidTap() {
+        makeBalloons(5)
         view.addSubview(balloonView)
-        animateBalloon()
+
+        
+        for i in 0..<3 {
+            let dispatchTime: DispatchTime = DispatchTime.now() + Double(1.7 * Double(i))
+            DispatchQueue.main.asyncAfter(deadline: dispatchTime) {
+                self.animateBalloon(self.balloonViews[i])
+            }
+        }
+
     }
 
-    private func animateBalloon() {
+    private func animateBalloon(_ balloonView: BalloonView) {
         let originBalloonX = FeedViewController.initialBalloonX - FeedViewController.balloonWidth
         let originBalloonY = FeedViewController.initialBalloonY - FeedViewController.balloonHeight
 
-        self.balloonView.frame = CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0)
-        self.balloonView.layoutIfNeeded()
+        balloonView.frame = CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0)
+        balloonView.layoutIfNeeded()
 
         let animator = UIViewPropertyAnimator(duration: 5.0, curve: .easeIn, animations: nil)
 
         let inflateAnimator = UIViewPropertyAnimator(duration: 1.0, curve: .linear) {
-            self.balloonView.frame = CGRect(x: originBalloonX, y: originBalloonY, width: FeedViewController.balloonWidth - 0.1, height: FeedViewController.balloonHeight - 0.1)
-            self.balloonView.layoutIfNeeded()
+            balloonView.frame = CGRect(x: originBalloonX, y: originBalloonY, width: FeedViewController.balloonWidth - 0.1, height: FeedViewController.balloonHeight - 0.1)
+            balloonView.layoutIfNeeded()
         }
 
         func completeInflationAnimator() {
-            self.balloonView.frame.size = CGSize(width: FeedViewController.balloonWidth, height: FeedViewController.balloonHeight)
-            self.balloonView.layoutIfNeeded()
+            balloonView.frame.size = CGSize(width: FeedViewController.balloonWidth, height: FeedViewController.balloonHeight)
+            balloonView.layoutIfNeeded()
         }
 
         func flyAnimator() {
-            self.balloonView.frame.origin.y = -FeedViewController.balloonHeight
-            self.balloonView.layoutIfNeeded()
+            balloonView.frame.origin.y = -FeedViewController.balloonHeight
+            balloonView.layoutIfNeeded()
         }
 
         animator.addAnimations(inflateAnimator.startAnimation)
@@ -77,7 +95,7 @@ class FeedViewController: UIViewController, TutorialDelegate {
         animator.addAnimations(flyAnimator, delayFactor: 0.2)
 
         animator.addCompletion {_ in
-            self.animateBalloon()
+            self.animateBalloon(balloonView)
         }
 
         animator.startAnimation()

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -22,8 +22,13 @@ class FeedViewController: UIViewController, TutorialDelegate {
     static let initialBalloonX = trailingMargin + balloonWidth
     static let initialBalloonY = screenSize.height - bottomMargin
 
+    static let balloonCount = 3
+    
+    private var balloonCycleCount: Int = 0
     private let balloonView = BalloonView(frame: CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0))
     private var balloonViews = [BalloonView]()
+    private var balloonLower: BalloonView?
+    private var balloonHigher: BalloonView?
     private var tutorialView: TutorialView?
 
     override func viewDidLoad() {
@@ -44,29 +49,34 @@ class FeedViewController: UIViewController, TutorialDelegate {
         view.addSubview(tutorialView)
     }
     
-    func makeBalloons(_ count: Int){
+    func makeBalloons(_ count: Int) {
         for i in 0..<count {
             let addBalloonView = BalloonView(frame: CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY + CGFloat(i * 20), width: 10, height: 10))
             balloonViews += [addBalloonView]
             view.addSubview(addBalloonView)
+            if( i == 0 ) {
+                balloonLower = addBalloonView
+            }
+            else if( i == count-1 ) {
+                balloonHigher = addBalloonView
+            }
         }
     }
     
     func startButtonDidTap() {
-        makeBalloons(5)
+        makeBalloons(FeedViewController.balloonCount)
         view.addSubview(balloonView)
-
         
-        for i in 0..<3 {
+        for i in 0..<FeedViewController.balloonCount {
             let dispatchTime: DispatchTime = DispatchTime.now() + Double(1.7 * Double(i))
             DispatchQueue.main.asyncAfter(deadline: dispatchTime) {
-                self.animateBalloon(self.balloonViews[i])
+                self.animateBalloon(self.balloonViews[i], numberOfBalloon: i)
             }
         }
 
     }
 
-    private func animateBalloon(_ balloonView: BalloonView) {
+    private func animateBalloon(_ balloonView: BalloonView, numberOfBalloon: Int) {
         let originBalloonX = FeedViewController.initialBalloonX - FeedViewController.balloonWidth
         let originBalloonY = FeedViewController.initialBalloonY - FeedViewController.balloonHeight
 
@@ -95,7 +105,13 @@ class FeedViewController: UIViewController, TutorialDelegate {
         animator.addAnimations(flyAnimator, delayFactor: 0.2)
 
         animator.addCompletion {_ in
-            self.animateBalloon(balloonView)
+            self.balloonCycleCount += 1
+            if( numberOfBalloon == 2) {
+                self.balloonCycleCount = 0
+            }
+            print(self.balloonCycleCount)
+            balloonView.layer.zPosition = CGFloat(self.balloonCycleCount)
+            self.animateBalloon(balloonView, numberOfBalloon: numberOfBalloon)
         }
 
         animator.startAnimation()
@@ -105,7 +121,7 @@ class FeedViewController: UIViewController, TutorialDelegate {
         super.didReceiveMemoryWarning()
     }
 
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?){
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         //画面遷移時にURLを設定する実装にひとまずしてある状態
         let vc = segue.destination as? UserFeedViewController
         vc!.userFeedURL = URL(string: "https://www.google.com")

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -49,7 +49,8 @@ class FeedViewController: UIViewController, TutorialDelegate {
     
     func makeBalloons(_ count: Int) {
         for i in 0..<count {
-            let addBalloonView = BalloonView(frame: CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY + CGFloat(i * 20), width: 10, height: 10))
+            let addBalloonView = BalloonView(frame: CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY + CGFloat(i * 20), width: 0, height: 0))
+            addBalloonView.textView.accessibilityIdentifier = "balloonText\(i)"
             balloonViews += [addBalloonView]
             view.addSubview(addBalloonView)
         }

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -49,7 +49,7 @@ class FeedViewController: UIViewController, TutorialDelegate {
     
     func makeBalloons(_ count: Int) {
         for i in 0..<count {
-            let addBalloonView = BalloonView(frame: CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY + CGFloat(i * 20), width: 0, height: 0))
+            let addBalloonView = BalloonView(frame: CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0))
             addBalloonView.textView.accessibilityIdentifier = "balloonText\(i)"
             balloonViews += [addBalloonView]
             view.addSubview(addBalloonView)

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -54,10 +54,9 @@ class FeedViewController: UIViewController, TutorialDelegate {
             let addBalloonView = BalloonView(frame: CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY + CGFloat(i * 20), width: 10, height: 10))
             balloonViews += [addBalloonView]
             view.addSubview(addBalloonView)
-            if( i == 0 ) {
+            if i == 0 {
                 balloonLower = addBalloonView
-            }
-            else if( i == count-1 ) {
+            } else if i == count - 1 {
                 balloonHigher = addBalloonView
             }
         }
@@ -106,10 +105,9 @@ class FeedViewController: UIViewController, TutorialDelegate {
 
         animator.addCompletion {_ in
             self.balloonCycleCount += 1
-            if( numberOfBalloon == 2) {
+            if numberOfBalloon == 2 {
                 self.balloonCycleCount = 0
             }
-            print(self.balloonCycleCount)
             balloonView.layer.zPosition = CGFloat(self.balloonCycleCount)
             self.animateBalloon(balloonView, numberOfBalloon: numberOfBalloon)
         }

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -48,10 +48,10 @@ class FeedViewController: UIViewController, TutorialDelegate {
     
     func makeBalloons(_ count: Int) {
         for i in 0..<count {
-            let addBalloonView = BalloonView(frame: CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0))
-            addBalloonView.textView.accessibilityIdentifier = "balloonText\(i)"
-            balloonViews += [addBalloonView]
-            view.addSubview(addBalloonView)
+            let balloonView = BalloonView(frame: CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0))
+            balloonView.textView.accessibilityIdentifier = "balloonText\(i)"
+            balloonViews += [balloonView]
+            view.addSubview(balloonView)
         }
     }
     

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -25,7 +25,6 @@ class FeedViewController: UIViewController, TutorialDelegate {
     static let balloonCount = 3
     
     private var balloonCycleCount: Int = 0
-    private let balloonView = BalloonView(frame: CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0))
     private var balloonViews = [BalloonView]()
     private var tutorialView: TutorialView?
 
@@ -58,7 +57,6 @@ class FeedViewController: UIViewController, TutorialDelegate {
     
     func startButtonDidTap() {
         makeBalloons(FeedViewController.balloonCount)
-        view.addSubview(balloonView)
         
         for i in 0..<FeedViewController.balloonCount {
             let dispatchTime: DispatchTime = DispatchTime.now() + Double(1.7 * Double(i))

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -27,8 +27,6 @@ class FeedViewController: UIViewController, TutorialDelegate {
     private var balloonCycleCount: Int = 0
     private let balloonView = BalloonView(frame: CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0))
     private var balloonViews = [BalloonView]()
-    private var balloonLower: BalloonView?
-    private var balloonHigher: BalloonView?
     private var tutorialView: TutorialView?
 
     override func viewDidLoad() {
@@ -54,11 +52,6 @@ class FeedViewController: UIViewController, TutorialDelegate {
             let addBalloonView = BalloonView(frame: CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY + CGFloat(i * 20), width: 10, height: 10))
             balloonViews += [addBalloonView]
             view.addSubview(addBalloonView)
-            if i == 0 {
-                balloonLower = addBalloonView
-            } else if i == count - 1 {
-                balloonHigher = addBalloonView
-            }
         }
     }
     

--- a/piyopiyoUITests/FeedUITests.swift
+++ b/piyopiyoUITests/FeedUITests.swift
@@ -24,14 +24,15 @@ class FeedUITests: XCTestCase {
     func testTapAppStart() {
         let app = XCUIApplication()
         let startButton = app.buttons["startButton"]
-        let commentTextView = app.textViews["commentLabel"]
-        let durationOfBalloon: TimeInterval = 5.0
+        let durationOfBalloon: TimeInterval = 6.0
         
         XCTAssert(startButton.exists)
         
         startButton.tap()
         XCTAssertFalse(startButton.exists)
-
-        XCTAssert(commentTextView.waitForExistence(timeout: durationOfBalloon))
+        
+        for i in 0..<3 {
+            XCTAssert(app.textViews["balloonText\(i)"].waitForExistence(timeout: durationOfBalloon))
+        }
     }
 }


### PR DESCRIPTION
### 何を解決するのか
- Micropostを表示するためのアニメーション付きふきだしを３つ作成し、上昇アニメーションを適用
    - より「ぼーっと見ていられる」クライアントアプリになった

### 詳細
- ` DispatchQueue.main.asyncAfter` で動的に作成したふきだしに対して一定時間の遅延後にアニメーションを実行する
- ふきだしが若干重なることがあるので、ふきだしの前後関係を適切に設定した

（ふきだしの様子）
<img src="https://user-images.githubusercontent.com/19523490/31167457-168e19fa-a92d-11e7-90d9-ebfae68dcb0f.gif" width="250">


### 期日
受信したMicropostをふきだしに適用するまで
若干優先度高め

### レビューポイント
- piyopiyo/Classes/Controllers/FeedViewController.swift
    - 複数のふきだしを動的に生成して、アニメーション開始時刻をずらすことで動画のような処理を実現している
    - この処理が妥当かどうかを確認して頂けると嬉しいです

### レビュアー
@shizunaito @Asuforce
