### PR TITLE
ふきだしにMicropostを表示させる

### DIFF
--- a/piyopiyo.xcodeproj/project.pbxproj
+++ b/piyopiyo.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		E4744B761F7CEC2D0013619D /* UserFeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4744B751F7CEC2D0013619D /* UserFeedTests.swift */; };
 		E4AE01DB1F84A761002A1446 /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AE01DA1F84A761002A1446 /* UserProfile.swift */; };
 		E4AE01DD1F84AC46002A1446 /* UserProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AE01DC1F84AC46002A1446 /* UserProfileTests.swift */; };
+		E4B874911F85E0CD00B7F0BF /* ContinuityMicroposts.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B874901F85E0CD00B7F0BF /* ContinuityMicroposts.swift */; };
 		E4D89DA01F833AE1006A419A /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D89D9F1F833AE0006A419A /* APIClient.swift */; };
 		E4D89DA21F833BE2006A419A /* Micropost.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D89DA11F833BE2006A419A /* Micropost.swift */; };
 		E4D89DA41F8383CD006A419A /* MicropostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D89DA31F8383CD006A419A /* MicropostTests.swift */; };
@@ -79,6 +80,7 @@
 		E4744B751F7CEC2D0013619D /* UserFeedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeedTests.swift; sourceTree = "<group>"; };
 		E4AE01DA1F84A761002A1446 /* UserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
 		E4AE01DC1F84AC46002A1446 /* UserProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileTests.swift; sourceTree = "<group>"; };
+		E4B874901F85E0CD00B7F0BF /* ContinuityMicroposts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuityMicroposts.swift; sourceTree = "<group>"; };
 		E4D89D9F1F833AE0006A419A /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		E4D89DA11F833BE2006A419A /* Micropost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Micropost.swift; sourceTree = "<group>"; };
 		E4D89DA31F8383CD006A419A /* MicropostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicropostTests.swift; sourceTree = "<group>"; };
@@ -153,6 +155,7 @@
 			children = (
 				AFBDE5B81F7A265500441353 /* .gitkeep */,
 				E4D89D9F1F833AE0006A419A /* APIClient.swift */,
+				E4B874901F85E0CD00B7F0BF /* ContinuityMicroposts.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -422,6 +425,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E4B874911F85E0CD00B7F0BF /* ContinuityMicroposts.swift in Sources */,
 				E4F7006A1F7A4E8E00869BD5 /* ProfileView.swift in Sources */,
 				E4F700701F7B9D3E00869BD5 /* UserFeedViewController.swift in Sources */,
 				AFBDE5C51F7A390C00441353 /* BalloonView.swift in Sources */,

--- a/piyopiyo.xcodeproj/project.pbxproj
+++ b/piyopiyo.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		E4AE01DB1F84A761002A1446 /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AE01DA1F84A761002A1446 /* UserProfile.swift */; };
 		E4AE01DD1F84AC46002A1446 /* UserProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AE01DC1F84AC46002A1446 /* UserProfileTests.swift */; };
 		E4B874911F85E0CD00B7F0BF /* ContinuityMicroposts.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B874901F85E0CD00B7F0BF /* ContinuityMicroposts.swift */; };
+		E4B874931F8600FD00B7F0BF /* ContinuityMicropostsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B874921F8600FD00B7F0BF /* ContinuityMicropostsTests.swift */; };
 		E4D89DA01F833AE1006A419A /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D89D9F1F833AE0006A419A /* APIClient.swift */; };
 		E4D89DA21F833BE2006A419A /* Micropost.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D89DA11F833BE2006A419A /* Micropost.swift */; };
 		E4D89DA41F8383CD006A419A /* MicropostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D89DA31F8383CD006A419A /* MicropostTests.swift */; };
@@ -81,6 +82,7 @@
 		E4AE01DA1F84A761002A1446 /* UserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
 		E4AE01DC1F84AC46002A1446 /* UserProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileTests.swift; sourceTree = "<group>"; };
 		E4B874901F85E0CD00B7F0BF /* ContinuityMicroposts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuityMicroposts.swift; sourceTree = "<group>"; };
+		E4B874921F8600FD00B7F0BF /* ContinuityMicropostsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuityMicropostsTests.swift; sourceTree = "<group>"; };
 		E4D89D9F1F833AE0006A419A /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		E4D89DA11F833BE2006A419A /* Micropost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Micropost.swift; sourceTree = "<group>"; };
 		E4D89DA31F8383CD006A419A /* MicropostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicropostTests.swift; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 				AF161F051F78A6FF00B2DD73 /* Info.plist */,
 				E4D89DA31F8383CD006A419A /* MicropostTests.swift */,
 				E4AE01DC1F84AC46002A1446 /* UserProfileTests.swift */,
+				E4B874921F8600FD00B7F0BF /* ContinuityMicropostsTests.swift */,
 			);
 			path = piyopiyoTests;
 			sourceTree = "<group>";
@@ -445,6 +448,7 @@
 			files = (
 				E4AE01DD1F84AC46002A1446 /* UserProfileTests.swift in Sources */,
 				AF161F041F78A6FF00B2DD73 /* piyopiyoTests.swift in Sources */,
+				E4B874931F8600FD00B7F0BF /* ContinuityMicropostsTests.swift in Sources */,
 				E4D89DA41F8383CD006A419A /* MicropostTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -27,10 +27,13 @@ class FeedViewController: UIViewController, TutorialDelegate {
     private var balloonCycleCount: Int = 0
     private var balloonViews = [BalloonView]()
     private var tutorialView: TutorialView?
+    
+    private var microposts = ContinuityMicroposts()
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        microposts.fetchMicroposts()
         tutorialView = TutorialView(frame: self.view.frame)
         if let tutorialView = tutorialView {
             tutorialView.delegate = self
@@ -73,6 +76,8 @@ class FeedViewController: UIViewController, TutorialDelegate {
 
         balloonView.frame = CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0)
         balloonView.layoutIfNeeded()
+        
+        balloonView.micropost = microposts.getMicropost()
 
         let animator = UIViewPropertyAnimator(duration: 5.0, curve: .easeIn, animations: nil)
 

--- a/piyopiyo/Classes/Helpers/ContinuityMicroposts.swift
+++ b/piyopiyo/Classes/Helpers/ContinuityMicroposts.swift
@@ -1,0 +1,27 @@
+//
+//  ContinuityMicroposts.swift
+//  piyopiyo
+//
+//  Created by shohei.ogata on 2017/10/05.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import Foundation
+
+class ContinuityMicroposts{
+    var microposts = [Micropost]()
+    static let lowestMicropostCount = 5
+    
+    func getMicropost(handler: @escaping ((Micropost) -> Void)) {
+        if( microposts.count < ContinuityMicroposts.lowestMicropostCount ) {
+            Micropost.fetchRandomMicroposts() { randomPosts in
+                self.microposts += randomPosts
+                handler(self.microposts.removeFirst())
+            }
+        }
+        else{
+            handler(self.microposts.removeFirst())
+        }
+    }
+}
+

--- a/piyopiyo/Classes/Helpers/ContinuityMicroposts.swift
+++ b/piyopiyo/Classes/Helpers/ContinuityMicroposts.swift
@@ -8,20 +8,33 @@
 
 import Foundation
 
-class ContinuityMicroposts{
-    var microposts = [Micropost]()
+class ContinuityMicroposts {
+    private var microposts = [Micropost]()
+    private var isRequestingMicroposts: Bool = false
     static let lowestMicropostCount = 5
     
-    func getMicropost(handler: @escaping ((Micropost) -> Void)) {
-        if( microposts.count < ContinuityMicroposts.lowestMicropostCount ) {
-            Micropost.fetchRandomMicroposts() { randomPosts in
+    var count: Int {
+        return microposts.count
+    }
+    
+    func fetchMicroposts() {
+        if !isRequestingMicroposts {
+            isRequestingMicroposts = true
+            Micropost.fetchRandomMicroposts { randomPosts in
                 self.microposts += randomPosts
-                handler(self.microposts.removeFirst())
+                self.isRequestingMicroposts = false
             }
         }
-        else{
-            handler(self.microposts.removeFirst())
+    }
+    
+    func getMicropost() -> Micropost? {
+        if microposts.count < ContinuityMicroposts.lowestMicropostCount {
+            self.fetchMicroposts()
+        }
+        if microposts.count != 0 {
+            return self.microposts.removeFirst()
+        } else {
+            return nil
         }
     }
 }
-

--- a/piyopiyo/Classes/Helpers/ContinuityMicroposts.swift
+++ b/piyopiyo/Classes/Helpers/ContinuityMicroposts.swift
@@ -29,10 +29,10 @@ class ContinuityMicroposts {
     
     func getMicropost() -> Micropost? {
         if microposts.count < ContinuityMicroposts.lowestMicropostCount {
-            self.fetchMicroposts()
+            fetchMicroposts()
         }
         if microposts.count != 0 {
-            return self.microposts.removeFirst()
+            return microposts.removeFirst()
         } else {
             return nil
         }

--- a/piyopiyo/Classes/Views/BalloonView.swift
+++ b/piyopiyo/Classes/Views/BalloonView.swift
@@ -12,6 +12,15 @@ class BalloonView: UIView {
     
     @IBOutlet weak var textView: UITextView!
     
+    var micropost: Micropost? {
+        didSet {
+            guard let micropost = micropost else {
+                return
+            }
+            textView.text = micropost.content
+        }
+    }
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setup()

--- a/piyopiyoTests/ContinuityMicropostsTests.swift
+++ b/piyopiyoTests/ContinuityMicropostsTests.swift
@@ -32,14 +32,10 @@ class ContinuityMicropostsTests: XCTestCase {
         waitForExpectations(timeout: 4, handler: nil)
         
         //取得したMicropostが正しく取得できるかどうかを確認
-        XCTAssertNotNil(microposts.getMicropost())
-        XCTAssertNotNil(microposts.getMicropost())
-        XCTAssertNotNil(microposts.getMicropost())
-        XCTAssertNotNil(microposts.getMicropost())
-        XCTAssertNotNil(microposts.getMicropost())
-        XCTAssertNotNil(microposts.getMicropost())
-        XCTAssertNotNil(microposts.getMicropost())
-        
+        for _ in 0..<7 {
+            XCTAssertNotNil(microposts.getMicropost())
+        }
+
         //Micropostが一定数を下回った時に新たにMicropostを取りに行ってくれているかどうか確認
         let fetchSecondMicropostExpectation: XCTestExpectation? = self.expectation(description: "fetchSecondMicroposts")
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 3) {

--- a/piyopiyoTests/ContinuityMicropostsTests.swift
+++ b/piyopiyoTests/ContinuityMicropostsTests.swift
@@ -1,0 +1,51 @@
+//
+//  ContinuityMicropostsTests.swift
+//  piyopiyoTests
+//
+//  Created by shohei.ogata on 2017/10/05.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import XCTest
+@testable import piyopiyo
+
+class ContinuityMicropostsTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testGetMicroposts() {
+        let microposts = ContinuityMicroposts()
+        microposts.fetchMicroposts()
+        
+        //初回Micropost取得の成功が３秒以内に終了するか否かを確認
+        let fetchFirstMicropostExpectation: XCTestExpectation? = self.expectation(description: "fetchFirstMicroposts")
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 3) {
+            XCTAssertEqual(microposts.count, 10)
+            fetchFirstMicropostExpectation?.fulfill()
+        }
+        waitForExpectations(timeout: 4, handler: nil)
+        
+        //取得したMicropostが正しく取得できるかどうかを確認
+        XCTAssertNotNil(microposts.getMicropost())
+        XCTAssertNotNil(microposts.getMicropost())
+        XCTAssertNotNil(microposts.getMicropost())
+        XCTAssertNotNil(microposts.getMicropost())
+        XCTAssertNotNil(microposts.getMicropost())
+        XCTAssertNotNil(microposts.getMicropost())
+        XCTAssertNotNil(microposts.getMicropost())
+        
+        //Micropostが一定数を下回った時に新たにMicropostを取りに行ってくれているかどうか確認
+        let fetchSecondMicropostExpectation: XCTestExpectation? = self.expectation(description: "fetchSecondMicroposts")
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 3) {
+            XCTAssertEqual(microposts.count, 13)
+            fetchSecondMicropostExpectation?.fulfill()
+        }
+        waitForExpectations(timeout: 4, handler: nil)
+    }
+}


### PR DESCRIPTION
### 何を解決するのか
- サーバからMicropostを取得してふきだしに表示する
    - Micropostは都度取得をするようにしている

### 詳細
- #35 （実装の詳細など）

<img src="https://user-images.githubusercontent.com/19523490/31217746-02fbf972-a9f3-11e7-8343-c96eb262629f.gif" width="250">


### 期日
Micropostを各種処理で利用し始めるまで
（優先度は若干高め）

### レビューポイント
- piyopiyo/Classes/Helpers/ContinuityMicroposts.swift
    - サーバからMicropostを取得してバッファに追加する
    - Micropostが足りなくなったらサーバに取りに行く
    - 詳細は #35
- piyopiyoTests/ContinuityMicropostsTests.swift
    - テストに抜けがないかどうか

### レビュアー
@shizunaito @Asuforce

