### PR TITLE
ひよこのアス比を修正

### DIFF
--- a/piyopiyo/Storyboards/Main.storyboard
+++ b/piyopiyo/Storyboards/Main.storyboard
@@ -34,7 +34,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="hiyoko" translatesAutoresizingMaskIntoConstraints="NO" id="s90-Ne-38h">
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="hiyoko" translatesAutoresizingMaskIntoConstraints="NO" id="s90-Ne-38h">
                                 <rect key="frame" x="275" y="567" width="100" height="100"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="100" id="sFz-BJ-Q9U"/>


### PR DESCRIPTION
### 何を解決するのか
FeedVCのひよこ画像のアス比がおかしかったので修正しました。

#### UI
before
<img width="200" alt="2017-10-06 12 25 05" src="https://user-images.githubusercontent.com/14357415/31264652-7aa018fc-aaa5-11e7-801f-5358a13e4cc1.png">

after
<img width="200" alt="2017-10-06 14 48 13" src="https://user-images.githubusercontent.com/14357415/31264659-808f3f72-aaa5-11e7-98c3-42d32de4fbe4.png">

### 詳細
特になし

### 期日
優先度低め

### レビューポイント
上記画像で表示が適切かどうか

### レビュアー
@piyoppi 