### PR TITLE
BackgroundviewタップでProfileViewを閉じる

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -34,7 +34,13 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     
     private var microposts = ContinuityMicroposts()
     private let profileView = ProfileView(frame: CGRect(origin: FeedViewController.originalProfilePoint, size: FeedViewController.originalProfileSize))
-    private var profileBackgroundView = UIView(frame: CGRect(origin: CGPoint.zero, size: FeedViewController.screenSize))
+
+    @IBOutlet weak var profileBackgroundView: UIView! {
+        didSet {
+            profileBackgroundView.isHidden = true
+        }
+    }
+
     private var activityIndicator: UIActivityIndicatorView! {
         didSet {
             activityIndicator.frame = CGRect(x: 0, y: 0, width: 150, height: 150)
@@ -58,7 +64,6 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             addTutorial(tutorialView: tutorialView)
         }
         profileView.delegate = self
-        profileBackgroundView.backgroundColor = ColorPalette.profileBackgroundColor
         activityIndicator = UIActivityIndicatorView()
         view.addSubview(activityIndicator)
     }
@@ -159,18 +164,18 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                 self.view.addSubview(self.profileView)
             }
         }
-        view.addSubview(profileBackgroundView)
+        profileBackgroundView.isHidden = false
 
         profileBackgroundView.layer.zPosition = CGFloat(FeedViewController.balloonCount + 1)
         profileView.layer.zPosition = CGFloat(FeedViewController.balloonCount + 2)
     }
 
     func closeButtonDidTap() {
-        profileBackgroundView.removeFromSuperview()
+        profileBackgroundView.isHidden = true
     }
 
     func showUserFeedButtonDidTap() {
-        profileBackgroundView.removeFromSuperview()
+        profileBackgroundView.isHidden = true
         isDismiss = true
         showingUserProfile = profileView.profile
         performSegue(withIdentifier: "showUserFeed", sender: nil)

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -174,6 +174,11 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         profileBackgroundView.isHidden = true
     }
 
+    @IBAction func profileBackgroundDidTap(_ sender: UITapGestureRecognizer) {
+        profileView.removeFromSuperview()
+        profileBackgroundView.isHidden = true
+    }
+
     func showUserFeedButtonDidTap() {
         profileBackgroundView.isHidden = true
         isDismiss = true

--- a/piyopiyo/Storyboards/Main.storyboard
+++ b/piyopiyo/Storyboards/Main.storyboard
@@ -41,16 +41,25 @@
                                     <constraint firstAttribute="width" secondItem="s90-Ne-38h" secondAttribute="height" multiplier="1:1" id="xpF-jq-uV2"/>
                                 </constraints>
                             </imageView>
+                            <view alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s4B-UH-64h">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="s90-Ne-38h" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="24d-C9-G4R"/>
+                            <constraint firstItem="s4B-UH-64h" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="4w1-L1-0RE"/>
+                            <constraint firstItem="s4B-UH-64h" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="J6u-we-jGi"/>
                             <constraint firstItem="s90-Ne-38h" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="LHd-p8-nXU"/>
+                            <constraint firstItem="s4B-UH-64h" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="VcZ-cx-Off"/>
+                            <constraint firstItem="s4B-UH-64h" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="cab-1j-zBO"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <navigationItem key="navigationItem" id="cGc-Bw-a8u"/>
                     <connections>
+                        <outlet property="profileBackgroundView" destination="s4B-UH-64h" id="d6r-zI-RH0"/>
                         <segue destination="Xpz-S5-9ha" kind="show" identifier="showUserFeed" id="eWn-JF-mp5"/>
                     </connections>
                 </viewController>

--- a/piyopiyo/Storyboards/Main.storyboard
+++ b/piyopiyo/Storyboards/Main.storyboard
@@ -44,6 +44,10 @@
                             <view alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s4B-UH-64h">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <gestureRecognizers/>
+                                <connections>
+                                    <outletCollection property="gestureRecognizers" destination="rBu-Vb-KHN" appends="YES" id="O63-Rm-zg5"/>
+                                </connections>
                             </view>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -64,6 +68,11 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer id="rBu-Vb-KHN">
+                    <connections>
+                        <action selector="profileBackgroundDidTap:" destination="BYZ-38-t0r" id="9r9-NF-rs8"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="488.80000000000001" y="35.532233883058474"/>
         </scene>


### PR DESCRIPTION
### 何を解決するのか
ProfileView表示の際に、その外側（`ProfileBackgroundView`）をタップしたら閉じられるようにした。

#### UI
<img width="300" alt="2017-09-28 14 40 40" src="https://user-images.githubusercontent.com/14357415/31272083-ab4d7570-aac4-11e7-8c51-9d5ccf6c92ed.gif">

### 詳細
特になし

### 期日
他の作業に関係ないため優先度低め

### 実機テスト
- [x] BackgroundViewタップでFeed画面に戻る

### レビューポイント
- `FeedViewController.swift`
  - `profileBackgroundView`の定義をIBOutletに変更し、`isHidden`パラメタで表示非表示を切り替え
  - `UITapGestureRecognizer`を`profileBackgroundView`に追加し、タップアクションに「閉じる」ボタンと同等のアクションを追加

### レビュアー
@piyoppi @Asuforce 