### PR TITLE
ふきだしの前後関係がおかしくなる不具合を修正

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -23,7 +23,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     static let initialBalloonY = screenSize.height - bottomMargin
 
     static let balloonCount = 3                             //ふきだしViewの個数
-    static let resetBalloonCountValue = 6                   //ふきだしアニメーションをリセットするタイミング（ふきだしをいくつアニメーションしたらリセットするか）
+    static let resetBalloonCountValue = 100                 //ふきだしアニメーションをリセットするタイミング（ふきだしをいくつアニメーションしたらリセットするか）
     private var resetTriggerBalloonNumber: Int?             //リセットのタイミング（nil以外でリセットをかける）
     
     private var balloonCycleCount: Int = 0

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -23,7 +23,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     static let initialBalloonY = screenSize.height - bottomMargin
 
     static let balloonCount = 3
-    static let balloonResetCountValue = 5
+    static let balloonResetCountValue = 6
     private var resetTriggerBalloonNumber: Int?
     
     private var balloonCycleCount: Int = 0
@@ -180,8 +180,8 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         }
         profileBackgroundView.isHidden = false
 
-        profileBackgroundView.layer.zPosition = CGFloat(FeedViewController.balloonCount + 1)
-        profileView.layer.zPosition = CGFloat(FeedViewController.balloonCount + 2)
+        profileBackgroundView.layer.zPosition = CGFloat(FeedViewController.balloonResetCountValue + 1)
+        profileView.layer.zPosition = CGFloat(FeedViewController.balloonResetCountValue + 2)
     }
 
     func closeButtonDidTap() {

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -22,9 +22,9 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     static let initialBalloonX = trailingMargin + balloonWidth
     static let initialBalloonY = screenSize.height - bottomMargin
 
-    static let balloonCount = 3
-    static let balloonResetCountValue = 6
-    private var resetTriggerBalloonNumber: Int?
+    static let balloonCount = 3                             //ふきだしViewの個数
+    static let resetBalloonCountValue = 6                   //ふきだしアニメーションをリセットするタイミング（ふきだしをいくつアニメーションしたらリセットするか）
+    private var resetTriggerBalloonNumber: Int?             //リセットのタイミング（nil以外でリセットをかける）
     
     private var balloonCycleCount: Int = 0
     private var balloonViews = [BalloonView]()
@@ -157,7 +157,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                     self.balloonCycleCount = 0
                     self.setupBalloons(FeedViewController.balloonCount)
                 }
-            } else if self.balloonCycleCount == FeedViewController.balloonResetCountValue-1 {
+            } else if self.balloonCycleCount == (FeedViewController.resetBalloonCountValue - 1) {
                 self.resetTriggerBalloonNumber = numberOfBalloon
                 nextBalloon()
             } else {
@@ -180,8 +180,8 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         }
         profileBackgroundView.isHidden = false
 
-        profileBackgroundView.layer.zPosition = CGFloat(FeedViewController.balloonResetCountValue + 1)
-        profileView.layer.zPosition = CGFloat(FeedViewController.balloonResetCountValue + 2)
+        profileBackgroundView.layer.zPosition = CGFloat(FeedViewController.resetBalloonCountValue + 1)
+        profileView.layer.zPosition = CGFloat(FeedViewController.resetBalloonCountValue + 2)
     }
 
     func closeButtonDidTap() {


### PR DESCRIPTION
### 何を解決するのか
- ふきだしの前後関係がおかしくなることがあるので修正を行なった
    - （おそらく）ふきだしの出現タイミングがずれることによって、まれに前後関係がおかしくなることがあった

### 詳細
- 今までの実装では、ふきだしのzPositionを1->2->3->1 のように、吹き出しの出現サイクルに合わせてインクリメントとリセット（3->1）を行なっていた
    - リセットのタイミングでふきだしが重なると前後関係がおかしくなる
    - リセット時には重ならないようにアニメーションを調整していたが、何らかの原因でタイミングがずれると重なってしまう
- 解決策として、カウンタのリセットが必要になったタイミング以降はふきだしを新たに表示させることはせず、ふきだしの出現タイミングをリセットするようにした
    - 原理的には絶対にふきだしの前後関係がくずれないようになった

（下の動画は `resetBalloonCountValue=4` のときの動作です。実際は `resetBalloonCountValue=100` で実装しています）
<img src="https://user-images.githubusercontent.com/19523490/31372233-beb2b2fc-adcf-11e7-8655-8bc9c5b7d351.gif" width="250">


### 期日
いそぎません

### レビューポイント
- piyopiyo/Classes/Controllers/FeedViewController.swift
    - <a href="https://github.com/pepabo-mobile-app-training/piyopiyo/pull/46/files#diff-239b59da1eb6e45e1d3b819625c03114R152">L152</a> <-ふきだしカウンタのリセット周りの実装が正しそうかどうか

### レビュアー
@shizunaito @Asuforce 
