### PR TITLE
ユーザーのMicropostを取得する関数及びテストを追加

### DIFF
--- a/piyopiyo/Classes/Helpers/APIClient.swift
+++ b/piyopiyo/Classes/Helpers/APIClient.swift
@@ -39,11 +39,13 @@ class APIClient {
 enum Endpoint {
     case randomMicroposts
     case userProfile(Int)
+    case userFeed(Int)
     
     func method() -> HTTPMethod {
         switch self {
         case .randomMicroposts: return .get
         case .userProfile: return .get
+        case .userFeed: return .get
         }
     }
     
@@ -51,6 +53,7 @@ enum Endpoint {
         switch self {
         case .randomMicroposts: return "/api/random"
         case .userProfile(let value): return "/api/users/\(String(value))/profile"
+        case .userFeed(let value): return "/api/users/\(String(value))"
         }
     }
 }

--- a/piyopiyo/Classes/Models/Micropost.swift
+++ b/piyopiyo/Classes/Models/Micropost.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import SwiftyJSON
 
 class Micropost {
     var userID: Int
@@ -17,13 +18,21 @@ class Micropost {
         self.userID = userID
     }
     
+    static func jsonToMicroposts(_ json: JSON) -> Array<Micropost> {
+        return json["microposts"].arrayValue.map {
+            Micropost(content: $0["content"].stringValue, userID: $0["user_id"].intValue)
+        }
+    }
+    
     static func fetchRandomMicroposts(handler: @escaping ((Array<Micropost>) -> Void)) {
         APIClient.request(endpoint: Endpoint.randomMicroposts) { json in
-            let randomMicroposts = json["microposts"].arrayValue.map {
-                Micropost(content: $0["content"].stringValue, userID: $0["user_id"].intValue)
-            }
-            
-            handler(randomMicroposts)
+            handler(jsonToMicroposts(json))
+        }
+    }
+    
+    static func fetchUsersMicroposts(userID: Int, handler: @escaping ((Array<Micropost>) -> Void)) {
+        APIClient.request(endpoint: Endpoint.userFeed(userID)) { json in
+            handler(jsonToMicroposts(json))
         }
     }
 }

--- a/piyopiyoTests/MicropostTests.swift
+++ b/piyopiyoTests/MicropostTests.swift
@@ -20,14 +20,24 @@ class MicropostTests: XCTestCase {
     }
     
     func testFatchRandomMicroposts() {
-        let fetchRandomMicropostExpectation: XCTestExpectation? = self.expectation(description: "fetchUserProfile")
+        let fetchRandomMicropostExpectation: XCTestExpectation? = self.expectation(description: "fetchRandomMicroposts")
 
-        Micropost.fetchRandomMicroposts() { micropost in
-            XCTAssertEqual(micropost.count, 10)
+        Micropost.fetchRandomMicroposts() { microposts in
+            XCTAssertEqual(microposts.count, 10)
             fetchRandomMicropostExpectation?.fulfill()
         }
         waitForExpectations(timeout: 10, handler: nil)
 
+    }
+    
+    func testFetchUsersMicroposts() {
+        let fetchUsersMicropostExpectation: XCTestExpectation? = self.expectation(description: "fetchUsersMicroposts")
+        
+        Micropost.fetchUsersMicroposts(userID: 1) { microposts in
+            XCTAssertNotEqual(microposts.count, 0)
+            fetchUsersMicropostExpectation?.fulfill()
+        }
+        waitForExpectations(timeout: 10, handler: nil)
     }
     
 }


### PR DESCRIPTION
### 何を解決するのか
- ユーザーのMicropostを取得するAPIクライアントを実装

### 詳細
- ユーザーのフィードを表示するStoryboard追加にあたり、ユーザーのMicropostを取得する必要が出た
    - `/api/users/:id` にユーザーのMicropostを取りに行くようにした

### 期日
優先度高め（ユーザーフィードのアプリ化を実装中のため）

### レビューポイント
- piyopiyo/Classes/Models/Micropost.swift
    - 重複する処理の一本化 `jsonToMicroposts()`
    - Micropost取得関数 `fetchUsersMicroposts()` の追加
- piyopiyoTests/MicropostTests.swift
    - 一部の誤表記を修正
    - テストを追加

### レビュアー
@shizunaito @Asuforce 
