### PR TITLE
ユーザープロフィールViewのサイズ調整

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -29,7 +29,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     private var balloonCycleCount: Int = 0
     private var balloonViews = [BalloonView]()
     
-    static let originalProfileSize = CGSize(width: 300, height: 533.5)
+    static let originalProfileSize = CGSize(width: 300, height: 390)
     static let originalProfilePoint = CGPoint(x: (screenSize.width - originalProfileSize.width)/2, y: (screenSize.height - originalProfileSize.height)/2)
 
     private var tutorialView: TutorialView?

--- a/piyopiyo/Xibs/ProfileView.xib
+++ b/piyopiyo/Xibs/ProfileView.xib
@@ -17,24 +17,24 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="300" height="533.5"/>
+            <rect key="frame" x="0.0" y="0.0" width="300" height="394"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="unknown_avatar" translatesAutoresizingMaskIntoConstraints="NO" id="tXe-ji-jIM">
-                    <rect key="frame" x="86" y="81" width="128" height="128"/>
+                    <rect key="frame" x="86" y="61" width="128" height="128"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="128" id="TeQ-yM-Efc"/>
                         <constraint firstAttribute="height" constant="128" id="iNF-Jr-Vd1"/>
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ユーザー名" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pkk-DH-BKU">
-                    <rect key="frame" x="79.5" y="229" width="142" height="33.5"/>
+                    <rect key="frame" x="79.5" y="209" width="142" height="33.5"/>
                     <fontDescription key="fontDescription" type="system" pointSize="28"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TWs-qF-ZK2">
-                    <rect key="frame" x="243" y="33" width="44" height="44"/>
+                    <rect key="frame" x="243" y="13" width="44" height="44"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="44" id="URm-ve-m85"/>
                         <constraint firstAttribute="width" constant="44" id="s1S-6S-i4B"/>
@@ -48,7 +48,7 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nFI-7O-MLE" customClass="ColorButton" customModule="piyopiyo" customModuleProvider="target">
-                    <rect key="frame" x="44" y="398" width="213" height="57"/>
+                    <rect key="frame" x="44" y="287" width="213" height="57"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="213" id="012-Di-mB5"/>
                         <constraint firstAttribute="height" constant="57" id="HPf-C9-Wo2"/>
@@ -83,11 +83,11 @@
                 <constraint firstItem="tXe-ji-jIM" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="e6Y-5G-FcN"/>
                 <constraint firstItem="nFI-7O-MLE" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="eMn-px-NZa"/>
                 <constraint firstItem="tXe-ji-jIM" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="geF-oV-0mw"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="nFI-7O-MLE" secondAttribute="bottom" constant="79" id="v9v-pF-T7J"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="nFI-7O-MLE" secondAttribute="bottom" constant="50" id="v9v-pF-T7J"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
-            <point key="canvasLocation" x="25" y="52"/>
+            <point key="canvasLocation" x="25" y="-18"/>
         </view>
     </objects>
     <resources>

--- a/piyopiyo/Xibs/ProfileView.xib
+++ b/piyopiyo/Xibs/ProfileView.xib
@@ -17,7 +17,7 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="300" height="394"/>
+            <rect key="frame" x="0.0" y="0.0" width="300" height="390"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="unknown_avatar" translatesAutoresizingMaskIntoConstraints="NO" id="tXe-ji-jIM">
@@ -48,7 +48,7 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nFI-7O-MLE" customClass="ColorButton" customModule="piyopiyo" customModuleProvider="target">
-                    <rect key="frame" x="44" y="287" width="213" height="57"/>
+                    <rect key="frame" x="44" y="283" width="213" height="57"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="213" id="012-Di-mB5"/>
                         <constraint firstAttribute="height" constant="57" id="HPf-C9-Wo2"/>


### PR DESCRIPTION
### 何を解決するのか
- ユーザープロフィール表示画面において、「ほかのつぶやき」ボタンに気づかないことがユーザーテストで判明した
    - ref: https://github.com/pepabo-mobile-app-training/piyopiyo/issues/44#issuecomment-335350874
    - ユーザーアイコンと「ほかのつぶやき」ボタンが離れていることが原因と考察
    - ユーザーアイコンとボタンの距離を近づけることでユーザーにボタンの存在に気づいてもらえるように期待

### 詳細
いままで：
<img width="250" alt="2017-09-27 14 48 57" src="https://user-images.githubusercontent.com/19523490/31376502-27e82cec-ade0-11e7-8d4b-bf51d8b2f062.png">

改善版：
<img width="250" alt="2017-10-10 17 18 27" src="https://user-images.githubusercontent.com/19523490/31376451-fdf14996-addf-11e7-898b-daca24d65daf.png">


### 期日
急ぎではないです

### レビューポイント
調整後のサイズが適切かどうか

### レビュアー
@shizunaito 
