### PR TITLE
UserFeedのデータを適用

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -210,6 +210,8 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                 guard let showingUserProfile = showingUserProfile else {
                     return
                 }
+
+                vc.profile = showingUserProfile
                 self.showingUserProfile = nil
             default:
                 break

--- a/piyopiyo/Classes/Controllers/UserFeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/UserFeedViewController.swift
@@ -14,6 +14,8 @@ class UserFeedViewController: UIViewController {
         didSet {
             let cellName = "FeedTableViewCell"
             feedTableView.register(UINib(nibName: cellName, bundle: nil), forCellReuseIdentifier: cellName)
+            feedTableView.estimatedRowHeight = 90
+            feedTableView.rowHeight = UITableViewAutomaticDimension
         }
     }
     

--- a/piyopiyo/Classes/Controllers/UserFeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/UserFeedViewController.swift
@@ -18,11 +18,18 @@ class UserFeedViewController: UIViewController {
     }
     
     var profile: UserProfile?
+    var microposts = [Micropost]()
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        fetchProfile(profile: profile)
+        if let profile = profile {
+            fetchProfile(profile: profile)
+            Micropost.fetchUsersMicroposts(userID: profile.userID) { microposts in
+                self.microposts = microposts
+                self.feedTableView.reloadData()
+            }
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -33,10 +40,7 @@ class UserFeedViewController: UIViewController {
         super.didReceiveMemoryWarning()
     }
 
-    private func fetchProfile(profile: UserProfile?) {
-        guard let profile = profile else {
-            return
-        }
+    private func fetchProfile(profile: UserProfile) {
         nameLabel.text = profile.name
         avatarImageView.sd_setImage(with: profile.avatarURL, placeholderImage: UIImage(named: "avatar"))
     }
@@ -47,17 +51,18 @@ class UserFeedViewController: UIViewController {
 extension UserFeedViewController: UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 5
+        return microposts.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 
         let cellName = "FeedTableViewCell"
 
-        guard let cell = feedTableView.dequeueReusableCell(withIdentifier: cellName, for: indexPath) as? FeedTableViewCell else {
+        guard let cell = feedTableView.dequeueReusableCell(withIdentifier: cellName, for: indexPath) as? FeedTableViewCell, let profile = profile else {
             return UITableViewCell()
         }
 
+        cell.update(profile: profile, micropost: microposts[indexPath.row])
         return cell
     }
 }

--- a/piyopiyo/Classes/Controllers/UserFeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/UserFeedViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
-import WebKit
+import SDWebImage
+
 class UserFeedViewController: UIViewController {
     
     @IBOutlet weak var avatarImageView: UIImageView! {
@@ -16,8 +17,12 @@ class UserFeedViewController: UIViewController {
         }
     }
     
+    var profile: UserProfile?
+
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        fetchProfile(profile: profile)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -26,6 +31,14 @@ class UserFeedViewController: UIViewController {
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
+    }
+
+    private func fetchProfile(profile: UserProfile?) {
+        guard let profile = profile else {
+            return
+        }
+        nameLabel.text = profile.name
+        avatarImageView.sd_setImage(with: profile.avatarURL, placeholderImage: UIImage(named: "avatar"))
     }
 }
 

--- a/piyopiyo/Classes/Models/Micropost.swift
+++ b/piyopiyo/Classes/Models/Micropost.swift
@@ -18,19 +18,19 @@ class Micropost {
         self.userID = userID
     }
     
-    static func jsonToMicroposts(_ json: JSON) -> Array<Micropost> {
+    static func jsonToMicroposts(_ json: JSON) -> [Micropost] {
         return json["microposts"].arrayValue.map {
             Micropost(content: $0["content"].stringValue, userID: $0["user_id"].intValue)
         }
     }
     
-    static func fetchRandomMicroposts(handler: @escaping ((Array<Micropost>) -> Void)) {
+    static func fetchRandomMicroposts(handler: @escaping (([Micropost]) -> Void)) {
         APIClient.request(endpoint: Endpoint.randomMicroposts) { json in
             handler(jsonToMicroposts(json))
         }
     }
     
-    static func fetchUsersMicroposts(userID: Int, handler: @escaping ((Array<Micropost>) -> Void)) {
+    static func fetchUsersMicroposts(userID: Int, handler: @escaping (([Micropost]) -> Void)) {
         APIClient.request(endpoint: Endpoint.userFeed(userID)) { json in
             handler(jsonToMicroposts(json))
         }

--- a/piyopiyo/Classes/Views/FeedTableViewCell.swift
+++ b/piyopiyo/Classes/Views/FeedTableViewCell.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SDWebImage
 
 class FeedTableViewCell: UITableViewCell {
     @IBOutlet weak var avatarImageView: UIImageView! {
@@ -27,4 +28,9 @@ class FeedTableViewCell: UITableViewCell {
 
     }
     
+    func update(profile: UserProfile, micropost: Micropost) {
+        nameLabel.text = profile.name
+        avatarImageView.sd_setImage(with: profile.avatarURL, placeholderImage: UIImage(named: "avatar"))
+        contentTextView.text = micropost.content
+    }
 }


### PR DESCRIPTION
### 何を解決するのか
下記のデータをUserFeedVCに適用した。
- UserVCからUserProfileを遷移時に受け取る
- Micropost情報をAPIから取得する

#### UI
<img width="399" alt="2017-10-10 18 47 18" src="https://user-images.githubusercontent.com/14357415/31380182-8b7042b2-adeb-11e7-86f6-b2d033026d6f.png">

### 詳細
特になし

### 期日

### レビューポイント
- `FeedViewController.swift`：遷移時にUserProfile情報を渡す
- `UserFeedViewController.swift`
  - `viewDidLoad`時にprofile情報を適用、Micropostを取得
  - 情報取得後にtableViewを更新
- `FeedTableViewCell.swift`：セルのupdate処理を追加

### レビュアー
@piyoppi @Asuforce 