### PR TITLE
tutorialを初回のみ表示させるよう変更

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -60,10 +60,17 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         super.viewDidLoad()
 
         microposts.fetchMicroposts()
-        tutorialView = TutorialView(frame: self.view.frame)
-        if let tutorialView = tutorialView {
-            tutorialView.delegate = self
-            addTutorial(tutorialView: tutorialView)
+
+        let defaults = UserDefaults.standard
+        if !defaults.bool(forKey: "startApp") {
+            tutorialView = TutorialView(frame: self.view.frame)
+            if let tutorialView = tutorialView {
+                tutorialView.delegate = self
+                addTutorial(tutorialView: tutorialView)
+            }
+        } else {
+            makeBalloons(FeedViewController.balloonCount)
+            setupBalloons(FeedViewController.balloonCount)
         }
         profileView.delegate = self
         activityIndicator = UIActivityIndicatorView()
@@ -107,6 +114,9 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     }
 
     func startButtonDidTap() {
+        let userDefault = UserDefaults.standard
+        userDefault.set(true, forKey: "startApp")
+
         makeBalloons(FeedViewController.balloonCount)
         setupBalloons(FeedViewController.balloonCount)
     }

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -61,8 +61,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
 
         microposts.fetchMicroposts()
 
-        let defaults = UserDefaults.standard
-        if !defaults.bool(forKey: "startApp") {
+        if !UserDefaults.standard.bool(forKey: "startApp") {
             tutorialView = TutorialView(frame: self.view.frame)
             if let tutorialView = tutorialView {
                 tutorialView.delegate = self
@@ -114,8 +113,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     }
 
     func startButtonDidTap() {
-        let userDefault = UserDefaults.standard
-        userDefault.set(true, forKey: "startApp")
+        UserDefaults.standard.set(true, forKey: "startApp")
 
         makeBalloons(FeedViewController.balloonCount)
         setupBalloons(FeedViewController.balloonCount)


### PR DESCRIPTION
### 何を解決するのか
現状チュートリアルが毎回表示されてしまっていたので、
**TutorialViewの「始める」ボタンを押したら、** 次回以降はチュートリアルを表示しないようにした。

### 詳細
[UserDefaults](https://developer.apple.com/documentation/foundation/userdefaults)を使用して、タップした時に`startApp`というkey値で`true`を入れるようにした。

### 期日
急ぎではありません

### レビューポイント
- `FeedViewController.swift`
  - `viewDidLoad`：`startApp`にtrueが入っていたらアニメーションを開始。入っていなかったらチュートリアルを表示
  - `startButtonDidTap()`：Userdefaultに`startApp`というkeyでtrueを入れる

### レビュアー
@Asuforce @piyoppi 