### PR TITLE
ふきだし速度を可変できるようにする

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -45,7 +45,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         }
     }
     
-    @IBOutlet weak var hiyoko: UIButton!
+    @IBOutlet weak var hiyokoButton: UIButton!
     
     private var activityIndicator: UIActivityIndicatorView! {
         didSet {
@@ -244,11 +244,11 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         let animator = UIViewPropertyAnimator(duration: 1.0, curve: .easeIn, animations: nil)
         
         let jumpingMotion = UIViewPropertyAnimator(duration: 0.5, curve: .easeOut) {
-            self.hiyoko.layer.position.y -= 20
+            self.hiyokoButton.layer.position.y -= 20
          }
   
         func landingMotion() {
-            self.hiyoko.layer.position.y += 20
+            self.hiyokoButton.layer.position.y += 20
         }
         animator.addAnimations(jumpingMotion.startAnimation)
         animator.addAnimations(landingMotion, delayFactor: 0.5)
@@ -257,7 +257,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
 
     }
     
-    @IBAction func hiyokoTapped(_ sender: UIButton) {
+    @IBAction func hiyokoTapped(_ sender: Any) {
         if balloonDuration >= 9.0 {
             balloonDuration = 3.0
         } else {

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -43,7 +43,9 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             profileBackgroundView.isHidden = true
         }
     }
-
+    
+    @IBOutlet weak var hiyoko: UIButton!
+    
     private var activityIndicator: UIActivityIndicatorView! {
         didSet {
             activityIndicator.frame = CGRect(x: 0, y: 0, width: 150, height: 150)

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -139,7 +139,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
 
         let animator = UIViewPropertyAnimator(duration: duration, curve: .easeIn, animations: nil)
 
-        let inflateAnimator = UIViewPropertyAnimator(duration: 1.0, curve: .linear) {
+        let inflateAnimator = UIViewPropertyAnimator(duration: 1.0, curve: .easeOut) {
             balloonView.frame = CGRect(x: originBalloonX, y: originBalloonY, width: FeedViewController.balloonWidth - 0.1, height: FeedViewController.balloonHeight - 0.1)
             balloonView.layoutIfNeeded()
         }
@@ -232,12 +232,32 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         }
     }
     
+    func jumpHiyoko() {
+        let animator = UIViewPropertyAnimator(duration: 1.0, curve: .easeIn, animations: nil)
+        
+        let jumpingMotion = UIViewPropertyAnimator(duration: 0.5, curve: .easeOut) {
+            self.hiyoko.layer.position.y -= 20
+            self.hiyoko.layoutIfNeeded()
+         }
+  
+        func landingMotion() {
+            self.hiyoko.layer.position.y += 20
+            self.hiyoko.layoutIfNeeded()
+        }
+        animator.addAnimations(jumpingMotion.startAnimation)
+        animator.addAnimations(landingMotion, delayFactor: 0.5)
+
+        animator.startAnimation()
+
+    }
+    
     @IBAction func hiyokoTapped(_ sender: UIButton) {
         if balloonDuration >= 9.0 {
             balloonDuration = 3.0
         } else {
             balloonDuration += 3.0
         }
+        jumpHiyoko()
         resetAnimateBalloon()
     }
     

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -25,6 +25,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     static let balloonCount = 3                             //ふきだしViewの個数
     static let resetBalloonCountValue = 100                 //ふきだしアニメーションをリセットするタイミング（ふきだしをいくつアニメーションしたらリセットするか）
     private var resetTriggerBalloonNumber: Int?             //リセットのタイミング（nil以外でリセットをかける）
+    private var balloonDuration: Double = 15.0
     
     private var balloonCycleCount: Int = 0
     private var balloonViews = [BalloonView]()
@@ -99,7 +100,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     
     func setupBalloons(_ count: Int) {
         for i in 0..<count {
-            let dispatchTime: DispatchTime = DispatchTime.now() + Double(1.7 * Double(i))
+            let dispatchTime: DispatchTime = DispatchTime.now() + Double(balloonDuration / Double(FeedViewController.balloonCount) * Double(i))
             DispatchQueue.main.asyncAfter(deadline: dispatchTime) {
                 self.animateBalloon(self.balloonViews[i], numberOfBalloon: i)
             }
@@ -123,7 +124,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         
         balloonView.micropost = microposts.getMicropost()
 
-        let animator = UIViewPropertyAnimator(duration: 5.0, curve: .easeIn, animations: nil)
+        let animator = UIViewPropertyAnimator(duration: balloonDuration, curve: .easeIn, animations: nil)
 
         let inflateAnimator = UIViewPropertyAnimator(duration: 1.0, curve: .linear) {
             balloonView.frame = CGRect(x: originBalloonX, y: originBalloonY, width: FeedViewController.balloonWidth - 0.1, height: FeedViewController.balloonHeight - 0.1)

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -25,8 +25,8 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     static let balloonCount = 3                             //ふきだしViewの個数
     static let resetBalloonCountValue = 100                 //ふきだしアニメーションをリセットするタイミング（ふきだしをいくつアニメーションしたらリセットするか）
     private var resetTriggerBalloonNumber: Int?             //リセットのタイミング（nil以外でリセットをかける）
-    private var latestAppearanceBalloonNumber = 0
-    private var balloonDuration: Double = 6.0
+    private var latestAppearanceBalloonNumber = 0           //さいごに表示を開始したふきだしの番号
+    private var balloonDuration: Double = 6.0               //ふきだしアニメーション時間
     
     private var balloonCycleCount: Int = 0
     private var balloonViews = [BalloonView]()

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -119,7 +119,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         setupBalloons(FeedViewController.balloonCount)
     }
     
-    func resetAnimateBalloon(){
+    func resetAnimateBalloon() {
         resetTriggerBalloonNumber = latestAppearanceBalloonNumber
         balloonCycleCount = 0
     }
@@ -237,12 +237,10 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         
         let jumpingMotion = UIViewPropertyAnimator(duration: 0.5, curve: .easeOut) {
             self.hiyoko.layer.position.y -= 20
-            self.hiyoko.layoutIfNeeded()
          }
   
         func landingMotion() {
             self.hiyoko.layer.position.y += 20
-            self.hiyoko.layoutIfNeeded()
         }
         animator.addAnimations(jumpingMotion.startAnimation)
         animator.addAnimations(landingMotion, delayFactor: 0.5)

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -25,7 +25,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     static let balloonCount = 3                             //ふきだしViewの個数
     static let resetBalloonCountValue = 100                 //ふきだしアニメーションをリセットするタイミング（ふきだしをいくつアニメーションしたらリセットするか）
     private var resetTriggerBalloonNumber: Int?             //リセットのタイミング（nil以外でリセットをかける）
-    private var balloonDuration: Double = 15.0
+    private var balloonDuration: Double = 6.0
     
     private var balloonCycleCount: Int = 0
     private var balloonViews = [BalloonView]()
@@ -219,6 +219,14 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             default:
                 break
         }
-        
     }
+    
+    @IBAction func hiyokoTapped(_ sender: UIButton) {
+        if balloonDuration >= 15.0 {
+            balloonDuration = 3.0
+        } else {
+            balloonDuration += 3.0
+        }
+    }
+    
 }

--- a/piyopiyo/Storyboards/Main.storyboard
+++ b/piyopiyo/Storyboards/Main.storyboard
@@ -37,7 +37,7 @@
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bg" translatesAutoresizingMaskIntoConstraints="NO" id="PY6-ie-Z08">
                                 <rect key="frame" x="-412.66666666666669" y="0.0" width="1200.3333333333333" height="812"/>
                             </imageView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z6r-0y-dU6" userLabel="hiyoko">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z6r-0y-dU6" userLabel="hiyoko">
                                 <rect key="frame" x="267" y="682" width="125" height="100"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="Z6r-0y-dU6" secondAttribute="height" multiplier="5:4" id="7fa-LO-jg1"/>

--- a/piyopiyo/Storyboards/Main.storyboard
+++ b/piyopiyo/Storyboards/Main.storyboard
@@ -44,6 +44,9 @@
                                     <constraint firstAttribute="height" constant="100" id="GHr-Bs-lq6"/>
                                 </constraints>
                                 <state key="normal" title="Button" image="hiyoko"/>
+                                <connections>
+                                    <action selector="hiyokoTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gUV-jI-EBv"/>
+                                </connections>
                             </button>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="glass_feed" translatesAutoresizingMaskIntoConstraints="NO" id="l2u-B9-Tql">
                                 <rect key="frame" x="0.0" y="765" width="375" height="60"/>

--- a/piyopiyo/Storyboards/Main.storyboard
+++ b/piyopiyo/Storyboards/Main.storyboard
@@ -38,7 +38,7 @@
                                 <rect key="frame" x="-412.66666666666669" y="0.0" width="1200.3333333333333" height="812"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z6r-0y-dU6" userLabel="hiyoko">
-                                <rect key="frame" x="266" y="682" width="125" height="100"/>
+                                <rect key="frame" x="267" y="682" width="125" height="100"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="Z6r-0y-dU6" secondAttribute="height" multiplier="5:4" id="7fa-LO-jg1"/>
                                     <constraint firstAttribute="height" constant="100" id="GHr-Bs-lq6"/>
@@ -71,7 +71,6 @@
                             <constraint firstItem="s4B-UH-64h" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="VcZ-cx-Off"/>
                             <constraint firstItem="s4B-UH-64h" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="cab-1j-zBO"/>
                             <constraint firstItem="l2u-B9-Tql" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="gFE-wJ-Qq6"/>
-                            <constraint firstAttribute="trailing" secondItem="Z6r-0y-dU6" secondAttribute="trailing" constant="-16" id="jCA-dv-6Fv"/>
                             <constraint firstAttribute="bottom" secondItem="PY6-ie-Z08" secondAttribute="bottom" id="nbu-lx-DM9"/>
                             <constraint firstItem="l2u-B9-Tql" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="sZg-lP-FCz"/>
                             <constraint firstItem="l2u-B9-Tql" firstAttribute="top" secondItem="Z6r-0y-dU6" secondAttribute="bottom" constant="-17" id="x5t-qw-a9p"/>
@@ -81,6 +80,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="cGc-Bw-a8u"/>
                     <connections>
+                        <outlet property="hiyoko" destination="Z6r-0y-dU6" id="WLC-pw-VFj"/>
                         <outlet property="profileBackgroundView" destination="s4B-UH-64h" id="d6r-zI-RH0"/>
                         <segue destination="Xpz-S5-9ha" kind="show" identifier="showUserFeed" id="eWn-JF-mp5"/>
                     </connections>

--- a/piyopiyo/Storyboards/Main.storyboard
+++ b/piyopiyo/Storyboards/Main.storyboard
@@ -86,7 +86,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="cGc-Bw-a8u"/>
                     <connections>
-                        <outlet property="hiyoko" destination="Z6r-0y-dU6" id="WLC-pw-VFj"/>
+                        <outlet property="hiyokoButton" destination="Z6r-0y-dU6" id="X7Z-J2-kCE"/>
                         <outlet property="profileBackgroundView" destination="s4B-UH-64h" id="d6r-zI-RH0"/>
                         <segue destination="Xpz-S5-9ha" kind="show" identifier="showUserFeed" id="eWn-JF-mp5"/>
                     </connections>

--- a/piyopiyo/Storyboards/Main.storyboard
+++ b/piyopiyo/Storyboards/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="7vJ-SZ-8XV">
-    <device id="retina5_9" orientation="portrait">
+    <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -15,7 +15,7 @@
             <objects>
                 <navigationController id="7vJ-SZ-8XV" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Tg5-9H-eGO">
-                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -31,14 +31,14 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="FeedViewController" customModule="piyopiyo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bg" translatesAutoresizingMaskIntoConstraints="NO" id="PY6-ie-Z08">
-                                <rect key="frame" x="-412.66666666666669" y="0.0" width="1200.3333333333333" height="812"/>
+                                <rect key="frame" x="-412.5" y="0.0" width="1200" height="667"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z6r-0y-dU6" userLabel="hiyoko">
-                                <rect key="frame" x="267" y="682" width="125" height="100"/>
+                                <rect key="frame" x="267" y="537" width="125" height="100"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="Z6r-0y-dU6" secondAttribute="height" multiplier="5:4" id="7fa-LO-jg1"/>
                                     <constraint firstAttribute="height" constant="100" id="GHr-Bs-lq6"/>
@@ -52,13 +52,13 @@
                                 </connections>
                             </button>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="glass_feed" translatesAutoresizingMaskIntoConstraints="NO" id="l2u-B9-Tql">
-                                <rect key="frame" x="0.0" y="765" width="375" height="60"/>
+                                <rect key="frame" x="0.0" y="620" width="375" height="60"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="pd8-Dc-SIR"/>
                                 </constraints>
                             </imageView>
-                            <view alpha="0.5" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="s4B-UH-64h">
-                                <rect key="frame" x="-227" y="333" width="375" height="667"/>
+                            <view alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s4B-UH-64h">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <gestureRecognizers/>
                                 <connections>

--- a/piyopiyo/Storyboards/Main.storyboard
+++ b/piyopiyo/Storyboards/Main.storyboard
@@ -37,13 +37,16 @@
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bg" translatesAutoresizingMaskIntoConstraints="NO" id="PY6-ie-Z08">
                                 <rect key="frame" x="-412.66666666666669" y="0.0" width="1200.3333333333333" height="812"/>
                             </imageView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z6r-0y-dU6" userLabel="hiyoko">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z6r-0y-dU6" userLabel="hiyoko">
                                 <rect key="frame" x="267" y="682" width="125" height="100"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="Z6r-0y-dU6" secondAttribute="height" multiplier="5:4" id="7fa-LO-jg1"/>
                                     <constraint firstAttribute="height" constant="100" id="GHr-Bs-lq6"/>
                                 </constraints>
                                 <state key="normal" title="Button" image="hiyoko"/>
+                                <state key="highlighted">
+                                    <color key="titleShadowColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
                                 <connections>
                                     <action selector="hiyokoTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gUV-jI-EBv"/>
                                 </connections>

--- a/piyopiyo/Storyboards/Main.storyboard
+++ b/piyopiyo/Storyboards/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="7vJ-SZ-8XV">
-    <device id="retina4_7" orientation="portrait">
+    <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -15,7 +15,7 @@
             <objects>
                 <navigationController id="7vJ-SZ-8XV" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Tg5-9H-eGO">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -31,27 +31,28 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="FeedViewController" customModule="piyopiyo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bg" translatesAutoresizingMaskIntoConstraints="NO" id="PY6-ie-Z08">
-                                <rect key="frame" x="-412.5" y="0.0" width="1200" height="667"/>
+                                <rect key="frame" x="-412.66666666666669" y="0.0" width="1200.3333333333333" height="812"/>
                             </imageView>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="hiyoko" translatesAutoresizingMaskIntoConstraints="NO" id="s90-Ne-38h">
-                                <rect key="frame" x="275" y="540" width="100" height="100"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z6r-0y-dU6" userLabel="hiyoko">
+                                <rect key="frame" x="266" y="682" width="125" height="100"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="100" id="sFz-BJ-Q9U"/>
-                                    <constraint firstAttribute="width" secondItem="s90-Ne-38h" secondAttribute="height" multiplier="1:1" id="xpF-jq-uV2"/>
+                                    <constraint firstAttribute="width" secondItem="Z6r-0y-dU6" secondAttribute="height" multiplier="5:4" id="7fa-LO-jg1"/>
+                                    <constraint firstAttribute="height" constant="100" id="GHr-Bs-lq6"/>
                                 </constraints>
-                            </imageView>
+                                <state key="normal" title="Button" image="hiyoko"/>
+                            </button>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="glass_feed" translatesAutoresizingMaskIntoConstraints="NO" id="l2u-B9-Tql">
-                                <rect key="frame" x="0.0" y="620" width="375" height="60"/>
+                                <rect key="frame" x="0.0" y="765" width="375" height="60"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="pd8-Dc-SIR"/>
                                 </constraints>
                             </imageView>
-                            <view alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s4B-UH-64h">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                            <view alpha="0.5" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="s4B-UH-64h">
+                                <rect key="frame" x="-227" y="333" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <gestureRecognizers/>
                                 <connections>
@@ -62,17 +63,18 @@
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="l2u-B9-Tql" secondAttribute="bottom" constant="-13" id="02E-Ul-wWe"/>
-                            <constraint firstItem="s90-Ne-38h" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="24d-C9-G4R"/>
                             <constraint firstItem="s4B-UH-64h" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="4w1-L1-0RE"/>
+                            <constraint firstAttribute="trailing" secondItem="Z6r-0y-dU6" secondAttribute="trailing" constant="-17" id="ICn-Q0-dUG"/>
                             <constraint firstItem="s4B-UH-64h" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="J6u-we-jGi"/>
                             <constraint firstItem="PY6-ie-Z08" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="N2t-gr-hJ4"/>
                             <constraint firstItem="PY6-ie-Z08" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="V8o-S5-e4Z"/>
                             <constraint firstItem="s4B-UH-64h" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="VcZ-cx-Off"/>
                             <constraint firstItem="s4B-UH-64h" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="cab-1j-zBO"/>
                             <constraint firstItem="l2u-B9-Tql" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="gFE-wJ-Qq6"/>
+                            <constraint firstAttribute="trailing" secondItem="Z6r-0y-dU6" secondAttribute="trailing" constant="-16" id="jCA-dv-6Fv"/>
                             <constraint firstAttribute="bottom" secondItem="PY6-ie-Z08" secondAttribute="bottom" id="nbu-lx-DM9"/>
-                            <constraint firstItem="s90-Ne-38h" firstAttribute="bottom" secondItem="l2u-B9-Tql" secondAttribute="bottom" constant="-40" id="r3R-9p-TYN"/>
                             <constraint firstItem="l2u-B9-Tql" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="sZg-lP-FCz"/>
+                            <constraint firstItem="l2u-B9-Tql" firstAttribute="top" secondItem="Z6r-0y-dU6" secondAttribute="bottom" constant="-17" id="x5t-qw-a9p"/>
                             <constraint firstItem="PY6-ie-Z08" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="ygj-Zh-eGn"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>


### PR DESCRIPTION
### 何を解決するのか
- ふきだし速度を可変にすることでユーザーがつぶやきを拾いやすくする
- ひよこタップでふきだし速度が切り替わるようにする

### 詳細
ひよこをタップしてふきだし移動速度が変わる様子
<img src="https://user-images.githubusercontent.com/19523490/31485520-1140a448-af6f-11e7-9221-18e15d03676e.gif" width="250">

- ひよこをタップするとひよこが少し跳ねる
- 移動中のふきだしの速度を変更できないので、移動中のふきだしがすべて上昇しきったタイミングで速度を変更している
- 速い -> ふつう -> 遅い の順で変化する。（デフォルトはふつう）

### 期日
急いでいません

### レビューポイント
- piyopiyo/Classes/Controllers/FeedViewController.swift
    - 行コメントを参照して、全体の挙動や変数名をみていただければと思います

### 実機テスト

下記の操作を行ってUIをテストしてください

- [x] ひよこをタップすると跳ねることを確認
- [x] ひよこをタップするとふきだし速度が減速（もしくは加速）されることを確認


### レビュアー
@shizunaito @Asuforce
