### PR TITLE
ユーザーフィードのNavigationBarのデザインを変更

### DIFF
--- a/piyopiyo/AppDelegate.swift
+++ b/piyopiyo/AppDelegate.swift
@@ -14,7 +14,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        UINavigationBar.appearance().barTintColor = ColorPalette.navigationBarBackgroundColor
+        UINavigationBar.appearance().tintColor = ColorPalette.navigationBarButtonTintColor
         return true
     }
 

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -78,6 +78,8 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         profileView.delegate = self
         activityIndicator = UIActivityIndicatorView()
         view.addSubview(activityIndicator)
+        
+        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "もどる", style: .plain, target: nil, action: nil)
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/piyopiyo/Classes/Helpers/ColorPalette.swift
+++ b/piyopiyo/Classes/Helpers/ColorPalette.swift
@@ -9,6 +9,6 @@
 import UIKit
 
 struct ColorPalette {
-    static let navigationBarButtonTintColor = UIColor(red: 105/255, green: 185/255, blue: 86/255, alpha: 0.5)
+    static let navigationBarButtonTintColor = UIColor.white
     static let navigationBarBackgroundColor = UIColor(red: 105/255, green: 185/255, blue: 86/255, alpha: 0.5)
 }

--- a/piyopiyo/Classes/Helpers/ColorPalette.swift
+++ b/piyopiyo/Classes/Helpers/ColorPalette.swift
@@ -9,5 +9,6 @@
 import UIKit
 
 struct ColorPalette {
-    static let profileBackgroundColor = UIColor(red: 0/255, green: 0/255, blue: 0/255, alpha: 0.5)
+    static let navigationBarButtonTintColor = UIColor(red: 105/255, green: 185/255, blue: 86/255, alpha: 0.5)
+    static let navigationBarBackgroundColor = UIColor(red: 105/255, green: 185/255, blue: 86/255, alpha: 0.5)
 }


### PR DESCRIPTION
### 何を解決するのか
- NavigationBarのデザインを変更し、アプリとしてのデザインの統一感を出す

### 詳細
芝の色と同一にしつつ、もどるボタンのテキストを変更しました
<img width="250" alt="2017-10-13 10 58 04" src="https://user-images.githubusercontent.com/19523490/31526999-75ecd01a-b005-11e7-965e-fbb70c3b92fe.png">

### 期日
急ぎではない

### レビューポイント
デザインがいい感じかどうか

### レビュアー
@shizunaito
