### PR TITLE
Twitter認証を追加

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,4 @@
 github "Alamofire/Alamofire" ~> 4.5
 github "SwiftyJSON/SwiftyJSON"
 github "rs/SDWebImage"
+github "mattdonnelly/Swifter"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,4 @@
 github "Alamofire/Alamofire" "4.5.1"
+github "rs/SDWebImage" "4.1.2"
+github "mattdonnelly/Swifter" "2.1.0"
 github "SwiftyJSON/SwiftyJSON" "3.1.4"
-github "rs/SDWebImage" "4.1.0"

--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ Xcodeのメニューから Product > Scheme > Edit Scheme を選択します。
 『Environment Variables』に下記を設定します。
 
 - Name: consumerKey, Value: Consumer Keyの値
-- Name: consumerSecret, Value: onsumer Secretの値
+- Name: consumerSecret, Value: Consumer Secretの値
 

--- a/README.md
+++ b/README.md
@@ -23,3 +23,21 @@
 
 ルールを削除したり、変更したりするときは`.swiftlint.yml`に記述します。
 ルールの詳細は、[SwiftLint/Rules.md](https://github.com/realm/SwiftLint/blob/master/Rules.md)に記載があります。
+
+### 環境変数の設定
+
+[Twitter API](https://developer.twitter.com/en.html)の使用のために以下の２つを環境変数として設定します。
+
+- Consumer Key (API Key)
+- Consumer Secret (API Secret)
+
+
+Xcodeのメニューから Product > Scheme > Edit Scheme を選択します。
+
+左サイドメニューから『Run』を選択します。
+
+『Environment Variables』に下記を設定します。
+
+- Name: consumerKey, Value: Consumer Keyの値
+- Name: consumerSecret, Value: onsumer Secretの値
+

--- a/piyopiyo.xcodeproj/project.pbxproj
+++ b/piyopiyo.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		AF161F041F78A6FF00B2DD73 /* piyopiyoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF161F031F78A6FF00B2DD73 /* piyopiyoTests.swift */; };
 		AF161F0F1F78A6FF00B2DD73 /* piyopiyoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF161F0E1F78A6FF00B2DD73 /* piyopiyoUITests.swift */; };
 		AF3F1E3D1F90701B004F9456 /* TwitterAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3F1E3C1F90701B004F9456 /* TwitterAuthorization.swift */; };
+		AF4260C41F90B77F00249975 /* TwitterAuthorizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4260C31F90B77F00249975 /* TwitterAuthorizationTests.swift */; };
+		AF4260C61F90C22500249975 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4260C51F90C22500249975 /* Error.swift */; };
 		AF914D221F908AB00085FE1C /* SwifteriOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF914D211F908AB00085FE1C /* SwifteriOS.framework */; };
 		AFBDE5B91F7A265500441353 /* .gitkeep in Resources */ = {isa = PBXBuildFile; fileRef = AFBDE5B81F7A265500441353 /* .gitkeep */; };
 		AFBDE5BB1F7A267300441353 /* .gitkeep in Resources */ = {isa = PBXBuildFile; fileRef = AFBDE5BA1F7A267300441353 /* .gitkeep */; };
@@ -83,6 +85,8 @@
 		AF161F0E1F78A6FF00B2DD73 /* piyopiyoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = piyopiyoUITests.swift; sourceTree = "<group>"; };
 		AF161F101F78A6FF00B2DD73 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AF3F1E3C1F90701B004F9456 /* TwitterAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterAuthorization.swift; sourceTree = "<group>"; };
+		AF4260C31F90B77F00249975 /* TwitterAuthorizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterAuthorizationTests.swift; sourceTree = "<group>"; };
+		AF4260C51F90C22500249975 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		AF914D211F908AB00085FE1C /* SwifteriOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwifteriOS.framework; path = Carthage/Build/iOS/SwifteriOS.framework; sourceTree = "<group>"; };
 		AFBDE5B81F7A265500441353 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		AFBDE5BA1F7A267300441353 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
@@ -179,6 +183,7 @@
 			children = (
 				AFBDE5B81F7A265500441353 /* .gitkeep */,
 				E4D89D9F1F833AE0006A419A /* APIClient.swift */,
+				AF4260C51F90C22500249975 /* Error.swift */,
 				E4B874901F85E0CD00B7F0BF /* ContinuityMicroposts.swift */,
 				AF3F1E3C1F90701B004F9456 /* TwitterAuthorization.swift */,
 				AF113E291F8609070026921A /* ColorPalette.swift */,
@@ -282,6 +287,7 @@
 				AF161F051F78A6FF00B2DD73 /* Info.plist */,
 				E4D89DA31F8383CD006A419A /* MicropostTests.swift */,
 				E4AE01DC1F84AC46002A1446 /* UserProfileTests.swift */,
+				AF4260C31F90B77F00249975 /* TwitterAuthorizationTests.swift */,
 				E4B874921F8600FD00B7F0BF /* ContinuityMicropostsTests.swift */,
 			);
 			path = piyopiyoTests;
@@ -478,6 +484,7 @@
 				E4D89DA21F833BE2006A419A /* Micropost.swift in Sources */,
 				AF113E2A1F8609070026921A /* ColorPalette.swift in Sources */,
 				E48B90A21F905C880080836C /* MicroContent.swift in Sources */,
+				AF4260C61F90C22500249975 /* Error.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -486,6 +493,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E4AE01DD1F84AC46002A1446 /* UserProfileTests.swift in Sources */,
+				AF4260C41F90B77F00249975 /* TwitterAuthorizationTests.swift in Sources */,
 				AF161F041F78A6FF00B2DD73 /* piyopiyoTests.swift in Sources */,
 				E4B874931F8600FD00B7F0BF /* ContinuityMicropostsTests.swift in Sources */,
 				E4D89DA41F8383CD006A419A /* MicropostTests.swift in Sources */,

--- a/piyopiyo.xcodeproj/project.pbxproj
+++ b/piyopiyo.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		AF161EF61F78A6FF00B2DD73 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AF161EF51F78A6FF00B2DD73 /* Assets.xcassets */; };
 		AF161F041F78A6FF00B2DD73 /* piyopiyoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF161F031F78A6FF00B2DD73 /* piyopiyoTests.swift */; };
 		AF161F0F1F78A6FF00B2DD73 /* piyopiyoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF161F0E1F78A6FF00B2DD73 /* piyopiyoUITests.swift */; };
+		AF3F1E3D1F90701B004F9456 /* TwitterAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3F1E3C1F90701B004F9456 /* TwitterAuthorization.swift */; };
+		AF914D221F908AB00085FE1C /* SwifteriOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF914D211F908AB00085FE1C /* SwifteriOS.framework */; };
 		AFBDE5B91F7A265500441353 /* .gitkeep in Resources */ = {isa = PBXBuildFile; fileRef = AFBDE5B81F7A265500441353 /* .gitkeep */; };
 		AFBDE5BB1F7A267300441353 /* .gitkeep in Resources */ = {isa = PBXBuildFile; fileRef = AFBDE5BA1F7A267300441353 /* .gitkeep */; };
 		AFBDE5BD1F7A268200441353 /* .gitkeep in Resources */ = {isa = PBXBuildFile; fileRef = AFBDE5BC1F7A268200441353 /* .gitkeep */; };
@@ -80,6 +82,8 @@
 		AF161F0A1F78A6FF00B2DD73 /* piyopiyoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = piyopiyoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF161F0E1F78A6FF00B2DD73 /* piyopiyoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = piyopiyoUITests.swift; sourceTree = "<group>"; };
 		AF161F101F78A6FF00B2DD73 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AF3F1E3C1F90701B004F9456 /* TwitterAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterAuthorization.swift; sourceTree = "<group>"; };
+		AF914D211F908AB00085FE1C /* SwifteriOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwifteriOS.framework; path = Carthage/Build/iOS/SwifteriOS.framework; sourceTree = "<group>"; };
 		AFBDE5B81F7A265500441353 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		AFBDE5BA1F7A267300441353 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		AFBDE5BC1F7A268200441353 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
@@ -114,6 +118,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AF914D221F908AB00085FE1C /* SwifteriOS.framework in Frameworks */,
 				E4B874951F8736A900B7F0BF /* SDWebImage.framework in Frameworks */,
 				AF087D8E1F78E3DB006C6BAF /* SwiftyJSON.framework in Frameworks */,
 				AF087D8F1F78E3DB006C6BAF /* Alamofire.framework in Frameworks */,
@@ -140,6 +145,7 @@
 		AF087D8B1F78E3DB006C6BAF /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				AF914D211F908AB00085FE1C /* SwifteriOS.framework */,
 				E4B874941F8736A900B7F0BF /* SDWebImage.framework */,
 				AF087D8D1F78E3DB006C6BAF /* Alamofire.framework */,
 				AF087D8C1F78E3DB006C6BAF /* SwiftyJSON.framework */,
@@ -174,6 +180,7 @@
 				AFBDE5B81F7A265500441353 /* .gitkeep */,
 				E4D89D9F1F833AE0006A419A /* APIClient.swift */,
 				E4B874901F85E0CD00B7F0BF /* ContinuityMicroposts.swift */,
+				AF3F1E3C1F90701B004F9456 /* TwitterAuthorization.swift */,
 				AF113E291F8609070026921A /* ColorPalette.swift */,
 			);
 			path = Helpers;
@@ -438,6 +445,7 @@
 				"$(SRCROOT)/Carthage/Build/iOS/Alamofire.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/SwiftyJSON.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/SDWebImage.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/SwifteriOS.framework",
 			);
 			outputPaths = (
 			);
@@ -457,6 +465,7 @@
 				E4F700701F7B9D3E00869BD5 /* UserFeedViewController.swift in Sources */,
 				E48B90A01F905C610080836C /* Tweet.swift in Sources */,
 				AFBDE5C51F7A390C00441353 /* BalloonView.swift in Sources */,
+				AF3F1E3D1F90701B004F9456 /* TwitterAuthorization.swift in Sources */,
 				E4D89DA01F833AE1006A419A /* APIClient.swift in Sources */,
 				AFC1F0231F8C9863007AB2E0 /* FeedTableViewCell.swift in Sources */,
 				E4F7006C1F7B81F300869BD5 /* TutorialView.swift in Sources */,

--- a/piyopiyo/AppDelegate.swift
+++ b/piyopiyo/AppDelegate.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SwifteriOS
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -16,6 +17,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         UINavigationBar.appearance().barTintColor = ColorPalette.navigationBarBackgroundColor
         UINavigationBar.appearance().tintColor = ColorPalette.navigationBarButtonTintColor
+        return true
+    }
+
+    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+        Swifter.handleOpenURL(url)
         return true
     }
 

--- a/piyopiyo/Classes/Helpers/Error.swift
+++ b/piyopiyo/Classes/Helpers/Error.swift
@@ -1,0 +1,13 @@
+//
+//  Error.swift
+//  piyopiyo
+//
+//  Created by shizuna.ito on 2017/10/13.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import Foundation
+
+enum TwitterClientError : Error {
+    case missingEnvironmentKeys
+}

--- a/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
+++ b/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
@@ -12,17 +12,20 @@ import SwifteriOS
 import Alamofire
 
 class TwitterAuthorization {
-    static private var sample: HTTPRequest?
-    static private let userDefaults = UserDefaults.standard
-    static private let env = ProcessInfo.processInfo.environment
+    private let userDefaults = UserDefaults.standard
+    private let consumerKey: String
+    private let consumerSecret: String
 
-    static func authorize(presentFrom: UIViewController?) throws -> Bool {
-        guard let consumerKey = env["consumerKey"], let consumerSecret = env["consumerSecret"] else {
-            print(env["consumerKey"] ?? "consumerKey is empty")
-            print(env["consumerSecret"] ?? "consumerSecret is empty")
+    init(consumerKey: String?, consumerSecret: String?) throws {
+        guard let consumerKey = consumerKey, let consumerSecret = consumerSecret else {
             throw TwitterClientError.missingEnvironmentKeys
         }
 
+        self.consumerKey = consumerKey
+        self.consumerSecret = consumerSecret
+    }
+
+    func authorize(presentFrom: UIViewController?) -> Bool {
         if isAuthorized() {
             return false
         }
@@ -34,8 +37,8 @@ class TwitterAuthorization {
             guard let token = token else {
                 return
             }
-            userDefaults.set(token.key, forKey: "twitter_key")
-            userDefaults.set(token.secret, forKey: "twitter_secret")
+            self.userDefaults.set(token.key, forKey: "twitter_key")
+            self.userDefaults.set(token.secret, forKey: "twitter_secret")
         }, failure: { (error) in
             // エラー処理
         })
@@ -43,7 +46,7 @@ class TwitterAuthorization {
         return true
     }
 
-    static private func isAuthorized() -> Bool {
+    private func isAuthorized() -> Bool {
         let key = userDefaults.object(forKey: "twitter_key")
         let secret = userDefaults.object(forKey: "twitter_secret")
 

--- a/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
+++ b/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
@@ -15,6 +15,7 @@ class TwitterAuthorization {
     private let userDefaults = UserDefaults.standard
     private let consumerKey: String
     private let consumerSecret: String
+    private let callbackURL = URL(string: "piyopiyo://")!
 
     init(consumerKey: String?, consumerSecret: String?) throws {
         guard let consumerKey = consumerKey, let consumerSecret = consumerSecret else {
@@ -31,7 +32,6 @@ class TwitterAuthorization {
         }
 
         let swifter = Swifter(consumerKey: consumerKey, consumerSecret: consumerSecret)
-        let callbackURL = URL(string: "piyopiyo://")!
 
         swifter.authorize(with: callbackURL, presentFrom: presentFrom, success: { (token, _) in
             guard let token = token else {
@@ -50,10 +50,6 @@ class TwitterAuthorization {
         let key = userDefaults.object(forKey: "twitter_key")
         let secret = userDefaults.object(forKey: "twitter_secret")
 
-        if key != nil, secret != nil {
-            return true
-        } else {
-            return false
-        }
+        return key != nil && secret != nil
     }
 }

--- a/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
+++ b/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
@@ -18,6 +18,8 @@ class TwitterAuthorization {
 
     static func authorize(presentFrom: UIViewController?) throws -> Bool {
         guard let consumerKey = env["consumerKey"], let consumerSecret = env["consumerSecret"] else {
+            print(env["consumerKey"] ?? "consumerKey is empty")
+            print(env["consumerSecret"] ?? "consumerSecret is empty")
             throw TwitterClientError.missingEnvironmentKeys
         }
 

--- a/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
+++ b/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
@@ -16,13 +16,13 @@ class TwitterAuthorization {
     static private let userDefaults = UserDefaults.standard
     static private let env = ProcessInfo.processInfo.environment
 
-    static func authorize(presentFrom: UIViewController?) {
+    static func authorize(presentFrom: UIViewController?) throws -> Bool {
         guard let consumerKey = env["consumerKey"], let consumerSecret = env["consumerSecret"] else {
-            return
+            throw TwitterClientError.missingEnvironmentKeys
         }
 
         if isAuthorized() {
-            return
+            return false
         }
 
         let swifter = Swifter(consumerKey: consumerKey, consumerSecret: consumerSecret)
@@ -35,8 +35,10 @@ class TwitterAuthorization {
             userDefaults.set(token.key, forKey: "twitter_key")
             userDefaults.set(token.secret, forKey: "twitter_secret")
         }, failure: { (error) in
-                // エラー処理
+            // エラー処理
         })
+
+        return true
     }
 
     static private func isAuthorized() -> Bool {

--- a/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
+++ b/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
@@ -14,13 +14,18 @@ import Alamofire
 class TwitterAuthorization {
     static private var sample: HTTPRequest?
     static private let userDefaults = UserDefaults.standard
+    static private let env = ProcessInfo.processInfo.environment
 
     static func authorize(presentFrom: UIViewController?) {
+        guard let consumerKey = env["consumerKey"], let consumerSecret = env["consumerSecret"] else {
+            return
+        }
+
         if isAuthorized() {
             return
         }
 
-        let swifter = Swifter(consumerKey: "xxx", consumerSecret: "xxx")
+        let swifter = Swifter(consumerKey: consumerKey, consumerSecret: consumerSecret)
         let callbackURL = URL(string: "piyopiyo://")!
 
         swifter.authorize(with: callbackURL, presentFrom: presentFrom, success: { (token, _) in

--- a/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
+++ b/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
@@ -1,0 +1,47 @@
+//
+//  TwitterAuthorization.swift
+//  piyopiyo
+//
+//  Created by shizuna.ito on 2017/10/13.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import SwifteriOS
+import Alamofire
+
+class TwitterAuthorization {
+    static private var sample: HTTPRequest?
+    static private let userDefaults = UserDefaults.standard
+
+    static func authorize(presentFrom: UIViewController?) {
+        if isAuthorized() {
+            return
+        }
+
+        let swifter = Swifter(consumerKey: "xxx", consumerSecret: "xxx")
+        let callbackURL = URL(string: "piyopiyo://")!
+
+        swifter.authorize(with: callbackURL, presentFrom: presentFrom, success: { (token, _) in
+            guard let token = token else {
+                return
+            }
+            userDefaults.set(token.key, forKey: "twitter_key")
+            userDefaults.set(token.secret, forKey: "twitter_secret")
+        }, failure: { (error) in
+                // エラー処理
+        })
+    }
+
+    static private func isAuthorized() -> Bool {
+        let key = userDefaults.object(forKey: "twitter_key")
+        let secret = userDefaults.object(forKey: "twitter_secret")
+
+        if key != nil, secret != nil {
+            return true
+        } else {
+            return false
+        }
+    }
+}

--- a/piyopiyo/Info.plist
+++ b/piyopiyo/Info.plist
@@ -20,6 +20,17 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>piyopiyo</string>
+			</array>
+		</dict>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/piyopiyoTests/TwitterAuthorizationTests.swift
+++ b/piyopiyoTests/TwitterAuthorizationTests.swift
@@ -20,16 +20,22 @@ class TwitterAuthorizationTests: XCTestCase {
     }
 
     func testAuthorize() {
+        let consumerKey = "test_key"
+        let consumerSecret = "test_secret"
         let userDefaults = UserDefaults.standard
-        
+
+        let twitterAuthorization = try? TwitterAuthorization(consumerKey: consumerKey, consumerSecret: consumerSecret)
+
+        XCTAssertNotNil(twitterAuthorization)
+
         UserDefaults.resetStandardUserDefaults()
-        
-        userDefaults.set("test_key", forKey: "twitter_key")
-        userDefaults.set("test_secret", forKey: "twitter_secret")
-        
+
+        userDefaults.set(consumerKey, forKey: "twitter_key")
+        userDefaults.set(consumerSecret, forKey: "twitter_secret")
+
         // すでにキーが存在するときfalseを返す（isAuthorized()メソッドの確認）
-        XCTAssertFalse(try TwitterAuthorization.authorize(presentFrom: UIViewController()))
-        
+        XCTAssertFalse(twitterAuthorization!.authorize(presentFrom: UIViewController()))
+
         userDefaults.removeObject(forKey: "twitter_key")
         userDefaults.removeObject(forKey: "twitter_secret")
     }

--- a/piyopiyoTests/TwitterAuthorizationTests.swift
+++ b/piyopiyoTests/TwitterAuthorizationTests.swift
@@ -1,0 +1,36 @@
+//
+//  TwitterAuthorizationTests.swift
+//  piyopiyoTests
+//
+//  Created by shizuna.ito on 2017/10/13.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import XCTest
+@testable import piyopiyo
+
+class TwitterAuthorizationTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testAuthorize() {
+        let userDefaults = UserDefaults.standard
+        
+        UserDefaults.resetStandardUserDefaults()
+        
+        userDefaults.set("test_key", forKey: "twitter_key")
+        userDefaults.set("test_secret", forKey: "twitter_secret")
+        
+        // すでにキーが存在するときfalseを返す（isAuthorized()メソッドの確認）
+        XCTAssertFalse(try TwitterAuthorization.authorize(presentFrom: UIViewController()))
+        
+        userDefaults.removeObject(forKey: "twitter_key")
+        userDefaults.removeObject(forKey: "twitter_secret")
+    }
+}


### PR DESCRIPTION
### 何を解決するのか
タイムラインにツイートを流すために、Swifterを導入し、Twitter認証を追加した。

### 詳細
- Swifterライブラリを導入
- Twitter認証クラスを追加
- API使用に必要なキーを環境変数に追加

### 期日
Tweet投稿実装まで（なるべく早め）

### レビューポイント
- `README.md`：環境変数追加方法を記述
- `AppDelegate.swift`：URLスキームを使って戻って来た時の処理を追加
- `Helpers/Error.swift`：エラーハンドリング用ファイルを作成及びswifterのエラーを追加
- `TwitterAuthorization.swift`：Twitter認証のヘルパー
- `piyopiyo/Info.plist`：URLスキーム`piyopiyo://`を追加
- `TwitterAuthorizationTests.swift`：Twitter認証の単体テスト

### レビュアー
@Asuforce @piyoppi 