### PR TITLE
画面遷移時にふきだしアニメーションに不具合が生じる問題を修正

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,6 @@
 disabled_rules:
 - trailing_whitespace
+- discarded_notification_center_observer
 
 excluded:
   - Carthage

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -241,10 +241,8 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                 if self.balloonCycleCount == (FeedViewController.resetBalloonCountValue - 1) {
                     //リセット条件を満たした場合（ふきだしカウンタが閾値を超えたら）リセットフラグを立てる
                     self.resetTrigger = ResetBalloonAnimation.reset
-                    nextBalloon()
-                } else {
-                    nextBalloon()
                 }
+                nextBalloon()
             }
         }
 

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -23,7 +23,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     static let initialBalloonY = screenSize.height - bottomMargin
 
     static let balloonCount = 3                             //ふきだしViewの個数
-    static let resetBalloonCountValue = 4                 //ふきだしアニメーションをリセットするタイミング（ふきだしをいくつアニメーションしたらリセットするか）
+    static let resetBalloonCountValue = 100                 //ふきだしアニメーションをリセットするタイミング（ふきだしをいくつアニメーションしたらリセットするか）
     
     enum ResetBalloonAnimation {
         case reset                                          //ふきだしループのリセット
@@ -110,20 +110,28 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     }
     
     func restartView() {
+
         if self.isEnterBackground {
             self.isEnterBackground = false
             if self.resetTrigger == ResetBalloonAnimation.none {
                 //ふきだしリセットが完了していたら開始を行う
                 self.setupBalloons(FeedViewController.balloonCount)
+                print("setup!!!!----")
+
             } else {
                 //ふきだしキャンセル完了前ならふきだしループをリセットする
                 self.resetTrigger = ResetBalloonAnimation.none
                 self.resetAnimateBalloon()
+                
+                print("restart!!!!----")
+
             }
         }
     }
     
     func prepareViewClosing() {
+        print("prepare")
+
         self.resetTrigger = ResetBalloonAnimation.cancel
         self.isEnterBackground = true
     }
@@ -165,6 +173,8 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                     if self.pendingSetupBalloonCount == 0 {
                         //ふきだしアニメーション開始待機中にリセットがかかった場合はリセットをかける
                         if self.resetTrigger == ResetBalloonAnimation.reset {
+                            print("restart2!!!")
+
                             self.restartAnimation()
                         }
                         self.resetTrigger = ResetBalloonAnimation.none
@@ -278,7 +288,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     }
     
     func restartAnimation() {
-        if self.animatingBalloonCount == 0 {
+        if self.animatingBalloonCount == 0  && self.pendingSetupBalloonCount == 0 {
             self.balloonCycleCount = 0
             self.resetTrigger = ResetBalloonAnimation.none
             self.setupBalloons(FeedViewController.balloonCount)

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -224,7 +224,9 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         
         animator.addCompletion {_ in
             self.animatingBalloonCount -= 1
-            if self.resetTrigger == ResetBalloonAnimation.cancel {
+            
+            switch self.resetTrigger {
+            case .cancel:
                 //キャンセル処理の場合はアニメーション終了後にキャンセル処理を行う
                 if self.animatingBalloonCount == 0 {
                     if self.pendingSetupBalloonCount == 0 {
@@ -232,15 +234,17 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                     }
                     self.balloonCycleCount = 0
                 }
-            } else if self.resetTrigger == ResetBalloonAnimation.reset {
+            case .reset:
                 //リセット処理の場合はアニメーション終了後に再開する
                 self.restartAnimation()
-            } else if self.balloonCycleCount == (FeedViewController.resetBalloonCountValue - 1) {
-                //リセット条件を満たした場合（ふきだしカウンタが閾値を超えたら）リセットフラグを立てる
-                self.resetTrigger = ResetBalloonAnimation.reset
-                nextBalloon()
-            } else {
-                nextBalloon()
+            default:
+                if self.balloonCycleCount == (FeedViewController.resetBalloonCountValue - 1) {
+                    //リセット条件を満たした場合（ふきだしカウンタが閾値を超えたら）リセットフラグを立てる
+                    self.resetTrigger = ResetBalloonAnimation.reset
+                    nextBalloon()
+                } else {
+                    nextBalloon()
+                }
             }
         }
 

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -155,16 +155,17 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             let dispatchTime: DispatchTime = DispatchTime.now() + Double(balloonDuration / Double(FeedViewController.balloonCount) * Double(i))
             DispatchQueue.main.asyncAfter(deadline: dispatchTime) {
                 self.pendingSetupBalloonCount -= 1
-                //リセットフラグが立っていたら処理を中断する
-                if self.resetTrigger != ResetBalloonAnimation.none {
+  
+                switch self.resetTrigger {
+                case .none:
+                     self.animateBalloon(self.balloonViews[i], numberOfBalloon: i, duration: balloonDuration)
+                case .reset:
                     if self.pendingSetupBalloonCount == 0 {
                         //ふきだしアニメーション開始待機中にリセットがかかった場合はリセットをかける
-                        if self.resetTrigger == ResetBalloonAnimation.reset {
-                            self.restartAnimation()
-                        }
+                        self.restartAnimation()
                     }
-                } else {
-                    self.animateBalloon(self.balloonViews[i], numberOfBalloon: i, duration: balloonDuration)
+                default:
+                    return
                 }
             }
         }

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -81,6 +81,21 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         view.addSubview(activityIndicator)
         
         self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "もどる", style: .plain, target: nil, action: nil)
+
+        NotificationCenter.default.addObserver(
+            forName:NSNotification.Name.UIApplicationDidBecomeActive,
+            object: nil,
+            queue: OperationQueue.main,
+            using: { _ in
+                self.resetAnimateBalloon()
+            })
+        
+        NotificationCenter.default.addObserver(
+            forName:NSNotification.Name.UIApplicationDidEnterBackground,
+            object: nil,
+            queue: OperationQueue.main,
+            using: { _ in
+            })
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -54,9 +54,6 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         }
     }
     
-    private var becomeActiveNotification: NSObjectProtocol?
-    private var enterBackgroundNotification: NSObjectProtocol?
-    
     @IBOutlet weak var hiyokoButton: UIButton!
     @IBOutlet weak var miniHiyokoButton: UIButton!
     
@@ -92,7 +89,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         
         navigationItem.backBarButtonItem = UIBarButtonItem(title: "もどる", style: .plain, target: nil, action: nil)
         
-        becomeActiveNotification = NotificationCenter.default.addObserver (
+        NotificationCenter.default.addObserver (
             forName: NSNotification.Name.UIApplicationDidBecomeActive,
             object: nil,
             queue: OperationQueue.main,
@@ -100,7 +97,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                self.restartView()
             })
         
-        enterBackgroundNotification = NotificationCenter.default.addObserver (
+        NotificationCenter.default.addObserver (
             forName:NSNotification.Name.UIApplicationDidEnterBackground,
             object: nil,
             queue: OperationQueue.main,

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -25,6 +25,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     static let balloonCount = 3                             //ふきだしViewの個数
     static let resetBalloonCountValue = 100                 //ふきだしアニメーションをリセットするタイミング（ふきだしをいくつアニメーションしたらリセットするか）
     private var resetTrigger: Bool = false                  //アニメーションのリセットフラグ
+    private var cancelTrigger: Bool = false
     private var animatingBalloonCount = 0                   //アニメーション再生中のふきだし数
     private var latestAppearanceBalloonNumber = 0           //さいごに表示を開始したふきだしの番号
     private var balloonDuration: Double = 6.0               //ふきだしアニメーション時間
@@ -88,7 +89,13 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             object: nil,
             queue: OperationQueue.main,
             using: { _ in
-                self.resetAnimateBalloon()
+                if self.animatingBalloonCount == 0 {
+                    self.setupBalloons(FeedViewController.balloonCount)
+                }
+                else {
+                    self.cancelTrigger = false
+                    self.resetAnimateBalloon()
+                }
             })
         
         NotificationCenter.default.addObserver(
@@ -96,6 +103,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             object: nil,
             queue: OperationQueue.main,
             using: { _ in
+                self.cancelTrigger = true
             })
     }
 
@@ -150,6 +158,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         resetTrigger = true
         balloonCycleCount = 0
     }
+ 
 
     private func animateBalloon(_ balloonView: BalloonView, numberOfBalloon: Int, duration: Double) {
         let originBalloonX = FeedViewController.initialBalloonX - FeedViewController.balloonWidth
@@ -194,8 +203,12 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         
         animator.addCompletion {_ in
             self.animatingBalloonCount -= 1
-            print(self.animatingBalloonCount)
-            if self.resetTrigger {
+            if self.cancelTrigger {
+                if self.animatingBalloonCount == 0 {
+                    self.cancelTrigger = false
+                    self.balloonCycleCount = 0
+                }
+            } else if self.resetTrigger {
                 if self.animatingBalloonCount == 0 {
                     self.resetTrigger = false
                     self.balloonCycleCount = 0

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -110,7 +110,6 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     }
     
     func restartView() {
-
         if self.isEnterBackground {
             self.isEnterBackground = false
             if self.resetTrigger == ResetBalloonAnimation.none {
@@ -132,7 +131,6 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(true)
         navigationController?.setNavigationBarHidden(true, animated: false)
-
         restartView()
     }
 

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -23,7 +23,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     static let initialBalloonY = screenSize.height - bottomMargin
 
     static let balloonCount = 3                             //ふきだしViewの個数
-    static let resetBalloonCountValue = 4                   //ふきだしアニメーションをリセットするタイミング（ふきだしをいくつアニメーションしたらリセットするか）
+    static let resetBalloonCountValue = 100                 //ふきだしアニメーションをリセットするタイミング（ふきだしをいくつアニメーションしたらリセットするか）
     
     enum ResetBalloonAnimation {
         case reset                                          //ふきだしループのリセット

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -116,22 +116,15 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             if self.resetTrigger == ResetBalloonAnimation.none {
                 //ふきだしリセットが完了していたら開始を行う
                 self.setupBalloons(FeedViewController.balloonCount)
-                print("setup!!!!----")
-
             } else {
                 //ふきだしキャンセル完了前ならふきだしループをリセットする
                 self.resetTrigger = ResetBalloonAnimation.none
                 self.resetAnimateBalloon()
-                
-                print("restart!!!!----")
-
             }
         }
     }
     
     func prepareViewClosing() {
-        print("prepare")
-
         self.resetTrigger = ResetBalloonAnimation.cancel
         self.isEnterBackground = true
     }
@@ -169,12 +162,9 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                 self.pendingSetupBalloonCount -= 1
                 //リセットフラグが立っていたら処理を中断する
                 if self.resetTrigger != ResetBalloonAnimation.none {
-                    print("Dispose_PendingAnimation")
                     if self.pendingSetupBalloonCount == 0 {
                         //ふきだしアニメーション開始待機中にリセットがかかった場合はリセットをかける
                         if self.resetTrigger == ResetBalloonAnimation.reset {
-                            print("restart2!!!")
-
                             self.restartAnimation()
                         }
                         self.resetTrigger = ResetBalloonAnimation.none
@@ -241,30 +231,21 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             self.animatingBalloonCount -= 1
             if self.resetTrigger == ResetBalloonAnimation.cancel {
                 //キャンセル処理の場合はアニメーション終了後にキャンセル処理を行う
-                print("cancel??")
-
                 if self.animatingBalloonCount == 0 {
                     if self.pendingSetupBalloonCount == 0 {
                         self.resetTrigger = ResetBalloonAnimation.none
-                        print("cancel complete")
-
                     }
                     self.balloonCycleCount = 0
                 }
             } else if self.resetTrigger == ResetBalloonAnimation.reset {
                 //リセット処理の場合はアニメーション終了後に再開する
                 self.restartAnimation()
-                print("reset trigger!! ")
-
             } else if self.balloonCycleCount == (FeedViewController.resetBalloonCountValue - 1) {
                 //リセット条件を満たした場合（ふきだしカウンタが閾値を超えたら）リセットフラグを立てる
                 self.resetTrigger = ResetBalloonAnimation.reset
                 nextBalloon()
-                print("next balloon 1")
             } else {
                 nextBalloon()
-                print("next balloon 2")
-
             }
         }
 
@@ -292,8 +273,6 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             self.balloonCycleCount = 0
             self.resetTrigger = ResetBalloonAnimation.none
             self.setupBalloons(FeedViewController.balloonCount)
-            print("restart!!!")
-
         }
     }
 

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -165,7 +165,6 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                         if self.resetTrigger == ResetBalloonAnimation.reset {
                             self.restartAnimation()
                         }
-                        self.resetTrigger = ResetBalloonAnimation.none
                     }
                 } else {
                     self.animateBalloon(self.balloonViews[i], numberOfBalloon: i, duration: balloonDuration)
@@ -269,8 +268,8 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     func restartAnimation() {
         if self.animatingBalloonCount == 0  && self.pendingSetupBalloonCount == 0 {
             self.balloonCycleCount = 0
-            self.resetTrigger = ResetBalloonAnimation.none
             self.setupBalloons(FeedViewController.balloonCount)
+            self.resetTrigger = ResetBalloonAnimation.none
         }
     }
 

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -54,6 +54,9 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         }
     }
     
+    private var becomeActiveNotification: NSObjectProtocol?
+    private var enterBackgroundNotification: NSObjectProtocol?
+    
     @IBOutlet weak var hiyokoButton: UIButton!
     @IBOutlet weak var miniHiyokoButton: UIButton!
     
@@ -89,11 +92,10 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         activityIndicator = UIActivityIndicatorView()
         view.addSubview(activityIndicator)
         
-        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "もどる", style: .plain, target: nil, action: nil)
-
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: "もどる", style: .plain, target: nil, action: nil)
         
-        NotificationCenter.default.addObserver(
-            forName:NSNotification.Name.UIApplicationDidBecomeActive,
+        becomeActiveNotification = NotificationCenter.default.addObserver (
+            forName: NSNotification.Name.UIApplicationDidBecomeActive,
             object: nil,
             queue: OperationQueue.main,
             using: { _ in
@@ -102,8 +104,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                     if self.resetTrigger == ResetBalloonAnimation.none {
                         //ふきだしリセットが完了していたら開始を行う
                         self.setupBalloons(FeedViewController.balloonCount)
-                    }
-                    else {
+                    } else {
                         //ふきだしキャンセル完了前ならふきだしループをリセットする
                         self.resetTrigger = ResetBalloonAnimation.none
                         self.resetAnimateBalloon()
@@ -111,7 +112,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                 }
             })
         
-        NotificationCenter.default.addObserver(
+        enterBackgroundNotification = NotificationCenter.default.addObserver (
             forName:NSNotification.Name.UIApplicationDidEnterBackground,
             object: nil,
             queue: OperationQueue.main,
@@ -182,7 +183,6 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         resetTrigger = ResetBalloonAnimation.reset
         balloonCycleCount = 0
     }
- 
 
     private func animateBalloon(_ balloonView: BalloonView, numberOfBalloon: Int, duration: Double) {
         let originBalloonX = FeedViewController.initialBalloonX - FeedViewController.balloonWidth


### PR DESCRIPTION
### 何を解決するのか
- 以下の条件を満たすときにふきだしアニメーションに不具合が生じる
    - アプリのホームボタンを押す
    - ユーザープロフィールからユーザーフィードに戻ったあと
    - （ふきだし画面が表示されなくなるとアニメーションが即時終了するので、そのへんが原因ではないかと考えられる）

### 詳細
- 画面がアクティブになるとき、バックグラウンドになるときに処理を捕捉する
    - バックグラウンド処理になるときにはアニメーションの「キャンセル」を行う
    - 「キャンセル」はアニメーションが終了したタイミングで「完了」される
    - アクティブになったときに「完了」状態ならふきだし再初期化
    - アクティブになったときに「キャンセル」状態なら
        - この状態のときにはアニメーションループはまだ回っている
        - 「リセット」状態にしてアニメーションループを回し続ける
- 「キャンセル」と「リセット」
    - `resetTrigger` には `reset` `cancel` `none` でアニメーションの状態を管理する
    - `reset` : アニメーションのループ処理を初期化（実行中のすべてのふきだしアニメーションが終了したら）
    - `cancel` : アニメーションのループ処理を停止（実行中のアニメーションループが完了してから）
    - `none` : アニメーション再生時の値
![dsc_0509](https://user-images.githubusercontent.com/19523490/31602402-e7f1a430-b297-11e7-9860-b952e607e8d3.JPG)

### 期日
急いでいないです

### レビューポイント
- ロジックが正しいかどうか
    - 詳細はラインコメントを参照してください

### レビュアー
@shizunaito @Asuforce
