### PR TITLE
プロフィール表示時にふきだしを押せてしまう問題の修正

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -91,7 +91,6 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             setupBalloons(FeedViewController.balloonCount)
             isDismiss = false
         }
-        setBalloonUserInteractionEnabled(true)
     }
 
     private func addTutorial(tutorialView: TutorialView?) {
@@ -205,6 +204,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             }
         }
         profileBackgroundView.isHidden = false
+        setBalloonUserInteractionEnabled(false)
 
         profileBackgroundView.layer.zPosition = CGFloat(FeedViewController.resetBalloonCountValue + 1)
         profileView.layer.zPosition = CGFloat(FeedViewController.resetBalloonCountValue + 2)
@@ -212,18 +212,19 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
 
     func closeButtonDidTap() {
         profileBackgroundView.isHidden = true
+        setBalloonUserInteractionEnabled(true)
     }
 
     @IBAction func profileBackgroundDidTap(_ sender: UITapGestureRecognizer) {
         profileView.removeFromSuperview()
         profileBackgroundView.isHidden = true
+        setBalloonUserInteractionEnabled(true)
     }
 
     func showUserFeedButtonDidTap() {
         profileBackgroundView.isHidden = true
         isDismiss = true
         showingUserProfile = profileView.profile
-        setBalloonUserInteractionEnabled(false)
         performSegue(withIdentifier: "showUserFeed", sender: nil)
     }
 
@@ -281,6 +282,5 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             balloonView.isUserInteractionEnabled = isEnabled
         }
     }
-    
     
 }

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -91,6 +91,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             setupBalloons(FeedViewController.balloonCount)
             isDismiss = false
         }
+        setBalloonUserInteractionEnabled(true)
     }
 
     private func addTutorial(tutorialView: TutorialView?) {
@@ -222,6 +223,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         profileBackgroundView.isHidden = true
         isDismiss = true
         showingUserProfile = profileView.profile
+        setBalloonUserInteractionEnabled(false)
         performSegue(withIdentifier: "showUserFeed", sender: nil)
     }
 
@@ -273,5 +275,12 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     @IBAction func miniHiyokoTapped(_ sender: Any) {
         
     }
+    
+    func setBalloonUserInteractionEnabled(_ isEnabled: Bool) {
+        balloonViews.forEach { (balloonView) in
+            balloonView.isUserInteractionEnabled = isEnabled
+        }
+    }
+    
     
 }


### PR DESCRIPTION
### 何を解決するのか
- プロフィールを表示している時にふきだしを押すと、ふきだしタップ処理が実行されてしまう
    - プロフィール表示ポップアップの範囲外をタップした場合はポップアップが閉じることが望ましい
    - ふきだしタップ処理によってポップアップが閉じない問題があった

### 詳細
修正後のふきだしタップの様子
<img src="https://user-images.githubusercontent.com/19523490/31645436-fc0b732a-b336-11e7-9128-a9acfd17596c.gif" width="250">

### 期日
急いでいません

### レビューポイント
- piyopiyo/Classes/Controllers/FeedViewController.swift
    - `setBalloonUserInteractionEnabled` 関数を用意し、ふきだしタップの可否を設定しています
 
### 実機テスト
- [x] 吹き出しを押してプロフィールを押した後、ポップアップ範囲外にあるふきだしをタップしてポップアップが閉じることを確認
- [x] その後に吹き出しがタップできることを確認
- [x] ポップアップを閉じるボタンで閉じた場合でも、その後に吹き出しがタップできることを確認

### レビュアー
@shizunaito @Asuforce
