### PR TITLE
Tweetを取得する機能を追加

### DIFF
--- a/piyopiyo.xcodeproj/project.pbxproj
+++ b/piyopiyo.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		AF161EF61F78A6FF00B2DD73 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AF161EF51F78A6FF00B2DD73 /* Assets.xcassets */; };
 		AF161F041F78A6FF00B2DD73 /* piyopiyoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF161F031F78A6FF00B2DD73 /* piyopiyoTests.swift */; };
 		AF161F0F1F78A6FF00B2DD73 /* piyopiyoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF161F0E1F78A6FF00B2DD73 /* piyopiyoUITests.swift */; };
+		AF3103F51F95E74900FBCDC7 /* ContinuityTweets.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3103F41F95E74900FBCDC7 /* ContinuityTweets.swift */; };
 		AF3F1E3D1F90701B004F9456 /* TwitterAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3F1E3C1F90701B004F9456 /* TwitterAuthorization.swift */; };
 		AF4260C41F90B77F00249975 /* TwitterAuthorizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4260C31F90B77F00249975 /* TwitterAuthorizationTests.swift */; };
 		AF4260C61F90C22500249975 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4260C51F90C22500249975 /* Error.swift */; };
@@ -84,6 +85,7 @@
 		AF161F0A1F78A6FF00B2DD73 /* piyopiyoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = piyopiyoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF161F0E1F78A6FF00B2DD73 /* piyopiyoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = piyopiyoUITests.swift; sourceTree = "<group>"; };
 		AF161F101F78A6FF00B2DD73 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AF3103F41F95E74900FBCDC7 /* ContinuityTweets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuityTweets.swift; sourceTree = "<group>"; };
 		AF3F1E3C1F90701B004F9456 /* TwitterAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterAuthorization.swift; sourceTree = "<group>"; };
 		AF4260C31F90B77F00249975 /* TwitterAuthorizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterAuthorizationTests.swift; sourceTree = "<group>"; };
 		AF4260C51F90C22500249975 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 				E4D89D9F1F833AE0006A419A /* APIClient.swift */,
 				AF4260C51F90C22500249975 /* Error.swift */,
 				E4B874901F85E0CD00B7F0BF /* ContinuityMicroposts.swift */,
+				AF3103F41F95E74900FBCDC7 /* ContinuityTweets.swift */,
 				AF3F1E3C1F90701B004F9456 /* TwitterAuthorization.swift */,
 				AF113E291F8609070026921A /* ColorPalette.swift */,
 			);
@@ -469,6 +472,7 @@
 				E4B874911F85E0CD00B7F0BF /* ContinuityMicroposts.swift in Sources */,
 				E4F7006A1F7A4E8E00869BD5 /* ProfileView.swift in Sources */,
 				E4F700701F7B9D3E00869BD5 /* UserFeedViewController.swift in Sources */,
+				AF3103F51F95E74900FBCDC7 /* ContinuityTweets.swift in Sources */,
 				E48B90A01F905C610080836C /* Tweet.swift in Sources */,
 				AFBDE5C51F7A390C00441353 /* BalloonView.swift in Sources */,
 				AF3F1E3D1F90701B004F9456 /* TwitterAuthorization.swift in Sources */,

--- a/piyopiyo.xcodeproj/project.pbxproj
+++ b/piyopiyo.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		AF161F041F78A6FF00B2DD73 /* piyopiyoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF161F031F78A6FF00B2DD73 /* piyopiyoTests.swift */; };
 		AF161F0F1F78A6FF00B2DD73 /* piyopiyoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF161F0E1F78A6FF00B2DD73 /* piyopiyoUITests.swift */; };
 		AF3103F51F95E74900FBCDC7 /* ContinuityTweets.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3103F41F95E74900FBCDC7 /* ContinuityTweets.swift */; };
+		AF3103F71F95F4E200FBCDC7 /* ContinuityMicroContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3103F61F95F4E200FBCDC7 /* ContinuityMicroContents.swift */; };
 		AF3F1E3D1F90701B004F9456 /* TwitterAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3F1E3C1F90701B004F9456 /* TwitterAuthorization.swift */; };
 		AF4260C41F90B77F00249975 /* TwitterAuthorizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4260C31F90B77F00249975 /* TwitterAuthorizationTests.swift */; };
 		AF4260C61F90C22500249975 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4260C51F90C22500249975 /* Error.swift */; };
@@ -86,6 +87,7 @@
 		AF161F0E1F78A6FF00B2DD73 /* piyopiyoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = piyopiyoUITests.swift; sourceTree = "<group>"; };
 		AF161F101F78A6FF00B2DD73 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AF3103F41F95E74900FBCDC7 /* ContinuityTweets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuityTweets.swift; sourceTree = "<group>"; };
+		AF3103F61F95F4E200FBCDC7 /* ContinuityMicroContents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuityMicroContents.swift; sourceTree = "<group>"; };
 		AF3F1E3C1F90701B004F9456 /* TwitterAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterAuthorization.swift; sourceTree = "<group>"; };
 		AF4260C31F90B77F00249975 /* TwitterAuthorizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterAuthorizationTests.swift; sourceTree = "<group>"; };
 		AF4260C51F90C22500249975 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
@@ -188,6 +190,7 @@
 				AF4260C51F90C22500249975 /* Error.swift */,
 				E4B874901F85E0CD00B7F0BF /* ContinuityMicroposts.swift */,
 				AF3103F41F95E74900FBCDC7 /* ContinuityTweets.swift */,
+				AF3103F61F95F4E200FBCDC7 /* ContinuityMicroContents.swift */,
 				AF3F1E3C1F90701B004F9456 /* TwitterAuthorization.swift */,
 				AF113E291F8609070026921A /* ColorPalette.swift */,
 			);
@@ -482,6 +485,7 @@
 				E48B90A61F90671C0080836C /* TwitterUserProfile.swift in Sources */,
 				E4F700661F7A2FBD00869BD5 /* ColorButton.swift in Sources */,
 				AF161EF11F78A6FF00B2DD73 /* FeedViewController.swift in Sources */,
+				AF3103F71F95F4E200FBCDC7 /* ContinuityMicroContents.swift in Sources */,
 				AF161EEF1F78A6FF00B2DD73 /* AppDelegate.swift in Sources */,
 				E4AE01DB1F84A761002A1446 /* MicropostUserProfile.swift in Sources */,
 				E48B90A41F9060AA0080836C /* UserProfile.swift in Sources */,

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -78,8 +78,15 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        let env = ProcessInfo.processInfo.environment
+        let defaults = UserDefaults.standard
 
-        microcontents = ContinuityTweets()
+        guard let consumerKey = env["consumerKey"], let consumerSecret = env["consumerSecret"],
+            let oauthToken = defaults.string(forKey: "twitter_key"), let oauthTokenSecret = defaults.string(forKey: "twitter_secret") else {
+                return
+        }
+
+        microcontents = ContinuityTweets(consumerKey: consumerKey, consumerSecret: consumerSecret, oauthToken: oauthToken, oauthTokenSecret: oauthTokenSecret)
 
         if let microcontents = microcontents {
             microcontents.fetchMicroContents()

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -53,7 +53,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
 
     private var tutorialView: TutorialView?
     
-    private var microposts = ContinuityMicroposts()
+    private var microcontents: ContinuityMicroContents?
     private let profileView = ProfileView(frame: CGRect(origin: FeedViewController.originalProfilePoint, size: FeedViewController.originalProfileSize))
 
     @IBOutlet weak var profileBackgroundView: UIView! {
@@ -79,7 +79,11 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        microposts.fetchMicroposts()
+        microcontents = ContinuityTweets()
+
+        if let microcontents = microcontents {
+            microcontents.fetchMicroContents()
+        }
 
         if !UserDefaults.standard.bool(forKey: "startApp") {
             tutorialView = TutorialView(frame: self.view.frame)
@@ -217,7 +221,10 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         balloonView.frame = CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0)
         balloonView.layoutIfNeeded()
         
-        balloonView.micropost = microposts.getMicropost()
+        guard let microcontents = microcontents else {
+            return
+        }
+        balloonView.micropost = microcontents.getMicroContent()
 
         let animator = UIViewPropertyAnimator(duration: duration, curve: .easeIn, animations: nil)
 

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -53,7 +53,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
 
     private var tutorialView: TutorialView?
     
-    private var microcontents: ContinuityMicroContents?
+    private var microcontents: ContinuityMicroContents = ContinuityMicroposts()
     private let profileView = ProfileView(frame: CGRect(origin: FeedViewController.originalProfilePoint, size: FeedViewController.originalProfileSize))
 
     @IBOutlet weak var profileBackgroundView: UIView! {
@@ -84,12 +84,6 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         if let consumerKey = env["consumerKey"], let consumerSecret = env["consumerSecret"],
             let oauthToken = defaults.string(forKey: "twitter_key"), let oauthTokenSecret = defaults.string(forKey: "twitter_secret") {
             microcontents = ContinuityTweets(consumerKey: consumerKey, consumerSecret: consumerSecret, oauthToken: oauthToken, oauthTokenSecret: oauthTokenSecret)
-        } else {
-            microcontents = ContinuityMicroposts()
-        }
-
-        if let microcontents = microcontents {
-            microcontents.fetchMicroContents()
         }
 
         if !UserDefaults.standard.bool(forKey: "startApp") {
@@ -228,9 +222,6 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         balloonView.frame = CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0)
         balloonView.layoutIfNeeded()
         
-        guard let microcontents = microcontents else {
-            return
-        }
         balloonView.micropost = microcontents.getMicroContent()
 
         let animator = UIViewPropertyAnimator(duration: duration, curve: .easeIn, animations: nil)

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -81,12 +81,12 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         let env = ProcessInfo.processInfo.environment
         let defaults = UserDefaults.standard
 
-        guard let consumerKey = env["consumerKey"], let consumerSecret = env["consumerSecret"],
-            let oauthToken = defaults.string(forKey: "twitter_key"), let oauthTokenSecret = defaults.string(forKey: "twitter_secret") else {
-                return
+        if let consumerKey = env["consumerKey"], let consumerSecret = env["consumerSecret"],
+            let oauthToken = defaults.string(forKey: "twitter_key"), let oauthTokenSecret = defaults.string(forKey: "twitter_secret") {
+            microcontents = ContinuityTweets(consumerKey: consumerKey, consumerSecret: consumerSecret, oauthToken: oauthToken, oauthTokenSecret: oauthTokenSecret)
+        } else {
+            microcontents = ContinuityMicroposts()
         }
-
-        microcontents = ContinuityTweets(consumerKey: consumerKey, consumerSecret: consumerSecret, oauthToken: oauthToken, oauthTokenSecret: oauthTokenSecret)
 
         if let microcontents = microcontents {
             microcontents.fetchMicroContents()
@@ -391,5 +391,4 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             balloonView.isUserInteractionEnabled = isEnabled
         }
     }
-    
 }

--- a/piyopiyo/Classes/Helpers/ContinuityMicroContents.swift
+++ b/piyopiyo/Classes/Helpers/ContinuityMicroContents.swift
@@ -1,0 +1,14 @@
+//
+//  ContinuityMicroContents.swift
+//  piyopiyo
+//
+//  Created by shizuna.ito on 2017/10/17.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import Foundation
+
+protocol ContinuityMicroContents {
+    func fetchMicroContents()
+    func getMicroContent() -> MicroContent?
+}

--- a/piyopiyo/Classes/Helpers/ContinuityMicroposts.swift
+++ b/piyopiyo/Classes/Helpers/ContinuityMicroposts.swift
@@ -8,16 +8,16 @@
 
 import Foundation
 
-class ContinuityMicroposts {
+class ContinuityMicroposts: ContinuityMicroContents {
     private var microposts = [Micropost]()
     private var isRequestingMicroposts: Bool = false
     static let lowestMicropostCount = 5
-    
+
     var count: Int {
         return microposts.count
     }
-    
-    func fetchMicroposts() {
+
+    func fetchMicroContents() {
         if !isRequestingMicroposts {
             isRequestingMicroposts = true
             Micropost.fetchRandomMicroposts { randomPosts in
@@ -26,10 +26,10 @@ class ContinuityMicroposts {
             }
         }
     }
-    
-    func getMicropost() -> Micropost? {
+
+    func getMicroContent() -> MicroContent? {
         if microposts.count < ContinuityMicroposts.lowestMicropostCount {
-            fetchMicroposts()
+            fetchMicroContents()
         }
         if microposts.count != 0 {
             return microposts.removeFirst()

--- a/piyopiyo/Classes/Helpers/ContinuityTweets.swift
+++ b/piyopiyo/Classes/Helpers/ContinuityTweets.swift
@@ -40,7 +40,9 @@ class ContinuityTweets: ContinuityMicroContents {
         if !isRequestingTweets {
             isRequestingTweets = true
             request = Tweet.fetchRandomTweets(swifter: swifter) { randomTweet in
-                self.tweets.append(randomTweet)
+                if !randomTweet.content.isEmpty {
+                    self.tweets.append(randomTweet)
+                }
 
                 if self.count == ContinuityTweets.maxTweetCount {
                     self.stop()

--- a/piyopiyo/Classes/Helpers/ContinuityTweets.swift
+++ b/piyopiyo/Classes/Helpers/ContinuityTweets.swift
@@ -13,22 +13,27 @@ class ContinuityTweets: ContinuityMicroContents {
     private var tweets = [Tweet]()
     private var isRequestingTweets: Bool = false
     private var request: HTTPRequest?
+
+    private let consumerKey: String
+    private let consumerSecret: String
+    private let oauthToken: String
+    private let oauthTokenSecret: String
+
     static let maxTweetCount = 50
     static let lowestTweetCount = 5
+
+    init(consumerKey: String, consumerSecret: String, oauthToken: String, oauthTokenSecret: String) {
+        self.consumerKey = consumerKey
+        self.consumerSecret = consumerSecret
+        self.oauthToken = oauthToken
+        self.oauthTokenSecret = oauthTokenSecret
+    }
 
     var count: Int {
         return tweets.count
     }
 
     func fetchMicroContents() {
-        let env = ProcessInfo.processInfo.environment
-        let defaults = UserDefaults.standard
-
-        guard let consumerKey = env["consumerKey"], let consumerSecret = env["consumerSecret"],
-            let oauthToken = defaults.string(forKey: "twitter_key"), let oauthTokenSecret = defaults.string(forKey: "twitter_secret") else {
-                return
-        }
-
         let swifter = Swifter(consumerKey: consumerKey, consumerSecret: consumerSecret, oauthToken: oauthToken, oauthTokenSecret: oauthTokenSecret)
 
         if !isRequestingTweets {

--- a/piyopiyo/Classes/Helpers/ContinuityTweets.swift
+++ b/piyopiyo/Classes/Helpers/ContinuityTweets.swift
@@ -14,6 +14,7 @@ class ContinuityTweets: ContinuityMicroContents {
     private var isRequestingTweets: Bool = false
     private var request: HTTPRequest?
 
+    private var swifter: Swifter
     private let consumerKey: String
     private let consumerSecret: String
     private let oauthToken: String
@@ -27,6 +28,8 @@ class ContinuityTweets: ContinuityMicroContents {
         self.consumerSecret = consumerSecret
         self.oauthToken = oauthToken
         self.oauthTokenSecret = oauthTokenSecret
+
+        self.swifter = Swifter(consumerKey: consumerKey, consumerSecret: consumerSecret, oauthToken: oauthToken, oauthTokenSecret: oauthTokenSecret)
     }
 
     var count: Int {
@@ -34,8 +37,6 @@ class ContinuityTweets: ContinuityMicroContents {
     }
 
     func fetchMicroContents() {
-        let swifter = Swifter(consumerKey: consumerKey, consumerSecret: consumerSecret, oauthToken: oauthToken, oauthTokenSecret: oauthTokenSecret)
-
         if !isRequestingTweets {
             isRequestingTweets = true
             request = Tweet.fetchRandomTweets(swifter: swifter) { randomTweet in

--- a/piyopiyo/Classes/Helpers/ContinuityTweets.swift
+++ b/piyopiyo/Classes/Helpers/ContinuityTweets.swift
@@ -1,0 +1,61 @@
+//
+//  ContinuityTweets.swift
+//  piyopiyo
+//
+//  Created by shizuna.ito on 2017/10/17.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import Foundation
+import SwifteriOS
+
+class ContinuityTweets {
+    private var tweets = [Tweet]()
+    private var isRequestingTweets: Bool = false
+    private var request: HTTPRequest?
+    static let maxTweetCount = 50
+    static let lowestTweetCount = 5
+
+    var count: Int {
+        return tweets.count
+    }
+
+    func fetchMicroposts() {
+        let env = ProcessInfo.processInfo.environment
+        let defaults = UserDefaults.standard
+
+        guard let consumerKey = env["consumerKey"], let consumerSecret = env["consumerSecret"],
+            let oauthToken = defaults.string(forKey: "twitter_key"), let oauthTokenSecret = defaults.string(forKey: "twitter_secret") else {
+                return
+        }
+
+        let swifter = Swifter(consumerKey: consumerKey, consumerSecret: consumerSecret, oauthToken: oauthToken, oauthTokenSecret: oauthTokenSecret)
+
+        if !isRequestingTweets {
+            isRequestingTweets = true
+            request = Tweet.fetchRandomTweets(swifter: swifter) { randomTweet in
+                self.tweets.append(randomTweet)
+
+                if self.count == ContinuityTweets.maxTweetCount {
+                    self.stop()
+                    self.isRequestingTweets = false
+                }
+            }
+        }
+    }
+
+    func getMicropost() -> Tweet? {
+        if tweets.count < ContinuityTweets.lowestTweetCount {
+            fetchMicroposts()
+        }
+        if tweets.count != 0 {
+            return tweets.removeFirst()
+        } else {
+            return nil
+        }
+    }
+
+    func stop() {
+        self.request?.stop()
+    }
+}

--- a/piyopiyo/Classes/Helpers/ContinuityTweets.swift
+++ b/piyopiyo/Classes/Helpers/ContinuityTweets.swift
@@ -9,7 +9,7 @@
 import Foundation
 import SwifteriOS
 
-class ContinuityTweets {
+class ContinuityTweets: ContinuityMicroContents {
     private var tweets = [Tweet]()
     private var isRequestingTweets: Bool = false
     private var request: HTTPRequest?
@@ -20,7 +20,7 @@ class ContinuityTweets {
         return tweets.count
     }
 
-    func fetchMicroposts() {
+    func fetchMicroContents() {
         let env = ProcessInfo.processInfo.environment
         let defaults = UserDefaults.standard
 
@@ -44,9 +44,9 @@ class ContinuityTweets {
         }
     }
 
-    func getMicropost() -> Tweet? {
+    func getMicroContent() -> MicroContent? {
         if tweets.count < ContinuityTweets.lowestTweetCount {
-            fetchMicroposts()
+            fetchMicroContents()
         }
         if tweets.count != 0 {
             return tweets.removeFirst()

--- a/piyopiyo/Classes/Helpers/ContinuityTweets.swift
+++ b/piyopiyo/Classes/Helpers/ContinuityTweets.swift
@@ -20,7 +20,7 @@ class ContinuityTweets: ContinuityMicroContents {
     private let oauthTokenSecret: String
 
     static let maxTweetCount = 50
-    static let lowestTweetCount = 5
+    static let lowestTweetCount = 15
 
     init(consumerKey: String, consumerSecret: String, oauthToken: String, oauthTokenSecret: String) {
         self.consumerKey = consumerKey

--- a/piyopiyo/Classes/Helpers/ContinuityTweets.swift
+++ b/piyopiyo/Classes/Helpers/ContinuityTweets.swift
@@ -60,7 +60,7 @@ class ContinuityTweets: ContinuityMicroContents {
         }
     }
 
-    func stop() {
+    private func stop() {
         self.request?.stop()
     }
 }

--- a/piyopiyo/Classes/Models/Tweet.swift
+++ b/piyopiyo/Classes/Models/Tweet.swift
@@ -26,6 +26,7 @@ class Tweet: MicroContent {
                   let userID = json["user"]["id"].double,
                   let name = json["user"]["name"].string,
                   let url = json["user"]["profile_image_url_https"].string else {
+                handler(Tweet(content: "", userID: "", profile: TwitterUserProfile(name: "", userID: "", avatarURL: nil)))
                 return
             }
             let profile = TwitterUserProfile(name: name, userID: String(userID), avatarURL: URL(string: url))

--- a/piyopiyo/Classes/Models/Tweet.swift
+++ b/piyopiyo/Classes/Models/Tweet.swift
@@ -7,13 +7,31 @@
 //
 
 import Foundation
+import SwifteriOS
 
 class Tweet: MicroContent {
     var userID: String
     var content: String
+    var profile: TwitterUserProfile
     
-    init(content: String, userID: String) {
+    init(content: String, userID: String, profile: TwitterUserProfile) {
         self.content = content
         self.userID = userID
+        self.profile = profile
+    }
+
+    static func fetchRandomTweets(swifter: Swifter, handler: @escaping ((Tweet) -> Void)) -> HTTPRequest {
+        return swifter.streamRandomSampleTweets(language:  ["ja"], progress: { json in
+            guard let content = json["text"].string,
+                  let userID = json["user"]["id"].double,
+                  let name = json["user"]["name"].string,
+                  let url = json["user"]["profile_image_url_https"].string else {
+                return
+            }
+            let profile = TwitterUserProfile(name: name, userID: String(userID), avatarURL: URL(string: url))
+            let tweet = Tweet(content: content, userID: String(userID), profile: profile)
+
+            handler(tweet)
+        })
     }
 }

--- a/piyopiyoTests/ContinuityMicropostsTests.swift
+++ b/piyopiyoTests/ContinuityMicropostsTests.swift
@@ -21,7 +21,7 @@ class ContinuityMicropostsTests: XCTestCase {
     
     func testGetMicroposts() {
         let microposts = ContinuityMicroposts()
-        microposts.fetchMicroposts()
+        microposts.fetchMicroContents()
         
         //初回Micropost取得の成功が３秒以内に終了するか否かを確認
         let fetchFirstMicropostExpectation: XCTestExpectation? = self.expectation(description: "fetchFirstMicroposts")
@@ -33,7 +33,7 @@ class ContinuityMicropostsTests: XCTestCase {
         
         //取得したMicropostが正しく取得できるかどうかを確認
         for _ in 0..<7 {
-            XCTAssertNotNil(microposts.getMicropost())
+            XCTAssertNotNil(microposts.getMicroContent())
         }
 
         //Micropostが一定数を下回った時に新たにMicropostを取りに行ってくれているかどうか確認

--- a/piyopiyoUITests/FeedUITests.swift
+++ b/piyopiyoUITests/FeedUITests.swift
@@ -7,14 +7,17 @@
 //
 
 import XCTest
+@testable import piyopiyo
 
 class FeedUITests: XCTestCase {
+    private let app = XCUIApplication()
 
     override func setUp() {
         super.setUp()
 
         continueAfterFailure = false
-        XCUIApplication().launch()
+        app.launchArguments.append(contentsOf: ["-startApp", "NO"])
+        app.launch()
     }
     
     override func tearDown() {
@@ -22,13 +25,13 @@ class FeedUITests: XCTestCase {
     }
     
     func testTapAppStart() {
-        let app = XCUIApplication()
         let startButton = app.buttons["startButton"]
         let durationOfBalloon: TimeInterval = 6.0
         
         XCTAssert(startButton.exists)
         
         startButton.tap()
+
         XCTAssertFalse(startButton.exists)
         
         for i in 0..<3 {


### PR DESCRIPTION
### 何を解決するのか
- Tweetを取得するヘルパークラスを追加
- TweetとMicropostのヘルパーが準拠するプロトコルを追加
- 表示の際にプロトコルを使うよう変更

- （テスト修正）FeedVCが2回目以降チュートリアルを表示しないことによるテストの不都合を修正

### 詳細
UIに関しては任意のTweetが表示されてしまうため今回は用意していません。

### 実機テスト
Tweet取得にユーザー本人のアクセストークンが必要なため、テストが難しいので実機で確認をお願いします。

- [x] FeedでTweetが適切に表示されるか

### 期日
ProfileViewをTwitterに対応させる前まで（優先度高めです）

### レビューポイント
- `ContinuityMicroContents.swift`：TweetとMicropostを取得するクラスのプロトコル
- `FeedViewController.swift`：micropost -> 上記プロトコルをもつmicrocontentに変更
- `ContinuityTweets.swift`：streamingAPIからTweetを取得するヘルパークラス
- `Tweet.swift`：プロパティとしてprofileを持たせるように変更

- `FeedUITests.swift`：セットアップ時に初回判定の`startApp`にfalseを設定するよう変更

### レビュアー
@Asuforce @piyoppi 