### PR TITLE
Twitter認証画面の表示

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,7 @@
 disabled_rules:
 - trailing_whitespace
 - discarded_notification_center_observer
+- type_body_length
 
 excluded:
   - Carthage

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -120,10 +120,14 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             if self.resetTrigger == ResetBalloonAnimation.none {
                 //ふきだしリセットが完了していたら開始を行う
                 self.setupBalloons(FeedViewController.balloonCount)
+                print("restart_view none")
+
             } else {
                 //ふきだしキャンセル完了前ならふきだしループをリセットする
                 self.resetTrigger = ResetBalloonAnimation.none
                 self.resetAnimateBalloon()
+                print("restart_view reset")
+
             }
         }
     }
@@ -131,6 +135,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     func prepareViewClosing() {
         self.resetTrigger = ResetBalloonAnimation.cancel
         self.isEnterBackground = true
+        print("prepare_view_closing")
     }
     
     func initializeTwitterAuthorization(handle: @escaping (_ result: Bool) -> Void) {
@@ -366,6 +371,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                 if !result {
                     self.microContentType = MicroContentType.micropost
                 }
+                print(result)
             }
         case .twitter:
             microContentType = MicroContentType.micropost

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -22,7 +22,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     static let initialBalloonX = trailingMargin + balloonWidth
     static let initialBalloonY = screenSize.height - bottomMargin
 
-    private var twitterAuthorization: TwitterAuthorization? = nil
+    private var twitterAuthorization: TwitterAuthorization?
     
     static let balloonCount = 3                             //ふきだしViewの個数
     static let resetBalloonCountValue = 100                 //ふきだしアニメーションをリセットするタイミング（ふきだしをいくつアニメーションしたらリセットするか）
@@ -362,8 +362,10 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         switch microContentType {
         case .micropost:
             microContentType = MicroContentType.twitter
-            _ = initializeTwitterAuthorization() { result in
-                
+            initializeTwitterAuthorization { result in
+                if !result {
+                    self.microContentType = MicroContentType.micropost
+                }
             }
         case .twitter:
             microContentType = MicroContentType.micropost

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -120,14 +120,9 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             if self.resetTrigger == ResetBalloonAnimation.none {
                 //ふきだしリセットが完了していたら開始を行う
                 self.setupBalloons(FeedViewController.balloonCount)
-                print("restart_view none")
-
             } else {
                 //ふきだしキャンセル完了前ならふきだしループをリセットする
-                self.resetTrigger = ResetBalloonAnimation.none
                 self.resetAnimateBalloon()
-                print("restart_view reset")
-
             }
         }
     }
@@ -135,7 +130,6 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     func prepareViewClosing() {
         self.resetTrigger = ResetBalloonAnimation.cancel
         self.isEnterBackground = true
-        print("prepare_view_closing")
     }
     
     func initializeTwitterAuthorization(handle: @escaping (_ result: Bool) -> Void) {
@@ -194,8 +188,10 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                         //ふきだしアニメーション開始待機中にリセットがかかった場合はリセットをかける
                         self.restartAnimation()
                     }
-                default:
-                    return
+                case .cancel:
+                    if self.pendingSetupBalloonCount == 0 {
+                        self.resetTrigger = ResetBalloonAnimation.none
+                    }
                 }
             }
         }
@@ -371,7 +367,6 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                 if !result {
                     self.microContentType = MicroContentType.micropost
                 }
-                print(result)
             }
         case .twitter:
             microContentType = MicroContentType.micropost

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -135,11 +135,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     func initializeTwitterAuthorization(handle: @escaping (_ result: Bool) -> Void) {
         if twitterAuthorization == nil {
             let env = ProcessInfo.processInfo.environment
-            guard let consumerKey = env["consumerKey"], let consumerSecret = env["consumerSecret"] else {
-                handle(false)
-                return
-            }
-            twitterAuthorization = try? TwitterAuthorization(consumerKey: consumerKey, consumerSecret: consumerSecret)
+            twitterAuthorization = try? TwitterAuthorization(consumerKey: env["consumerKey"], consumerSecret:  env["consumerSecret"])
         }
         
         if let twitterAuthorization = twitterAuthorization {

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -143,7 +143,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         }
         
         if let twitterAuthorization = twitterAuthorization {
-            _ = twitterAuthorization.authorize(presentFrom: self, handle: handle)
+            twitterAuthorization.authorize(presentFrom: self, handle: handle)
         } else {
             handle(false)
         }

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -22,6 +22,8 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     static let initialBalloonX = trailingMargin + balloonWidth
     static let initialBalloonY = screenSize.height - bottomMargin
 
+    private var twitterAuthorization: TwitterAuthorization? = nil
+    
     static let balloonCount = 3                             //ふきだしViewの個数
     static let resetBalloonCountValue = 100                 //ふきだしアニメーションをリセットするタイミング（ふきだしをいくつアニメーションしたらリセットするか）
     private var resetTriggerBalloonNumber: Int?             //リセットのタイミング（nil以外でリセットをかける）
@@ -80,7 +82,17 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         activityIndicator = UIActivityIndicatorView()
         view.addSubview(activityIndicator)
         
+       
+        
         self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "もどる", style: .plain, target: nil, action: nil)
+    }
+    
+    func initializeTwitterAuthorization() {
+        let env = ProcessInfo.processInfo.environment
+        guard let consumerKey = env["consumerKey"], let consumerSecret = env["consumerSecret"] else {
+            return
+        }
+        twitterAuthorization = try? TwitterAuthorization(consumerKey: consumerKey, consumerSecret: consumerSecret)
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
+++ b/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
@@ -43,7 +43,6 @@ class TwitterAuthorization {
             self.userDefaults.set(token.secret, forKey: "twitter_secret")
             handle(true)
         }, failure: { (error) in
-            // エラー処理
             handle(false)
         })
     }

--- a/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
+++ b/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
@@ -17,7 +17,7 @@ class TwitterAuthorization {
     private let consumerSecret: String
     private let callbackURL = URL(string: "piyopiyo://")!
 
-    init(consumerKey: String?, consumerSecret: String?) throws {
+    init(consumerKey: String?, consumerSecret: String? ) throws {
         guard let consumerKey = consumerKey, let consumerSecret = consumerSecret else {
             throw TwitterClientError.missingEnvironmentKeys
         }
@@ -26,24 +26,25 @@ class TwitterAuthorization {
         self.consumerSecret = consumerSecret
     }
 
-    func authorize(presentFrom: UIViewController?) -> Bool {
+    func authorize(presentFrom: UIViewController?, handle: @escaping (_ result: Bool) -> Void) {
         if isAuthorized() {
-            return false
+            handle(false)
         }
 
         let swifter = Swifter(consumerKey: consumerKey, consumerSecret: consumerSecret)
 
         swifter.authorize(with: callbackURL, presentFrom: presentFrom, success: { (token, _) in
             guard let token = token else {
+                handle(false)
                 return
             }
             self.userDefaults.set(token.key, forKey: "twitter_key")
             self.userDefaults.set(token.secret, forKey: "twitter_secret")
+            handle(true)
         }, failure: { (error) in
             // エラー処理
+            handle(false)
         })
-
-        return true
     }
 
     private func isAuthorized() -> Bool {

--- a/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
+++ b/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
@@ -28,7 +28,8 @@ class TwitterAuthorization {
 
     func authorize(presentFrom: UIViewController?, handle: @escaping (_ result: Bool) -> Void) {
         if isAuthorized() {
-            handle(false)
+            handle(true)
+            return
         }
 
         let swifter = Swifter(consumerKey: consumerKey, consumerSecret: consumerSecret)

--- a/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
+++ b/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
@@ -17,7 +17,7 @@ class TwitterAuthorization {
     private let consumerSecret: String
     private let callbackURL = URL(string: "piyopiyo://")!
 
-    init(consumerKey: String?, consumerSecret: String? ) throws {
+    init(consumerKey: String?, consumerSecret: String?) throws {
         guard let consumerKey = consumerKey, let consumerSecret = consumerSecret else {
             throw TwitterClientError.missingEnvironmentKeys
         }

--- a/piyopiyoTests/TwitterAuthorizationTests.swift
+++ b/piyopiyoTests/TwitterAuthorizationTests.swift
@@ -37,7 +37,7 @@ class TwitterAuthorizationTests: XCTestCase {
         let twitterAuthorizationException: XCTestExpectation? = self.expectation(description: "twitterAuthorization")
         
         twitterAuthorization!.authorize(presentFrom: UIViewController()) { result in
-            XCTAssertFalse(result)
+            XCTAssertTrue(result)
             userDefaults.removeObject(forKey: "twitter_key")
             userDefaults.removeObject(forKey: "twitter_secret")
             twitterAuthorizationException?.fulfill()

--- a/piyopiyoTests/TwitterAuthorizationTests.swift
+++ b/piyopiyoTests/TwitterAuthorizationTests.swift
@@ -34,9 +34,15 @@ class TwitterAuthorizationTests: XCTestCase {
         userDefaults.set(consumerSecret, forKey: "twitter_secret")
 
         // すでにキーが存在するときfalseを返す（isAuthorized()メソッドの確認）
-        XCTAssertFalse(twitterAuthorization!.authorize(presentFrom: UIViewController()))
+        let twitterAuthorizationException: XCTestExpectation? = self.expectation(description: "twitterAuthorization")
+        
+        twitterAuthorization!.authorize(presentFrom: UIViewController()) { result in
+            XCTAssertFalse(result)
+            userDefaults.removeObject(forKey: "twitter_key")
+            userDefaults.removeObject(forKey: "twitter_secret")
+            twitterAuthorizationException?.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
 
-        userDefaults.removeObject(forKey: "twitter_key")
-        userDefaults.removeObject(forKey: "twitter_secret")
     }
 }

--- a/piyopiyoTests/TwitterAuthorizationTests.swift
+++ b/piyopiyoTests/TwitterAuthorizationTests.swift
@@ -33,9 +33,8 @@ class TwitterAuthorizationTests: XCTestCase {
         userDefaults.set(consumerKey, forKey: "twitter_key")
         userDefaults.set(consumerSecret, forKey: "twitter_secret")
 
-        // すでにキーが存在するときfalseを返す（isAuthorized()メソッドの確認）
+        // すでにキーが存在するときは、クロージャの引数にTrueがセットされる（isAuthorized()メソッドの確認）
         let twitterAuthorizationException: XCTestExpectation? = self.expectation(description: "twitterAuthorization")
-        
         twitterAuthorization!.authorize(presentFrom: UIViewController()) { result in
             XCTAssertTrue(result)
             userDefaults.removeObject(forKey: "twitter_key")


### PR DESCRIPTION
### 何を解決するのか
- ユーザーにTwitterの認証画面を提供する
    - ユーザーが許可した場合のみAccess Tokenを取得するため
- MicropostとTweetの切り替えを行えるように準備
- （副次的に）認証画面から戻ってきた時にふきだしが表示されなくなる不具合を修正

### 詳細
- `TwitterAuthorization` クラスの `Authorize` の実装を変更
    - 非同期で返される結果にも対応するため、関数の実行結果をクロージャ経由で渡すように変更
- ` microContentType` を定義    
    - 表示すべき情報がMicropostかTweetかを格納するための変数
- ミニひよこをタップした時に `microContentType` を変更できるように実装
    - とりあえず切り替えのみ
    - トークンの取得に失敗した場合はMicropostに戻す処理を実装

### 期日
Twitterクライアントの実装中なのでなるべく早めでお願いします

### レビューポイント
- 行コメントを参照してください
- piyopiyo/Classes/Controllers/FeedViewController.swift
    - Authorizeまわりの実装が使い勝手良くなっているかどうか
    - MicropostとTweetを適切に切り替えられそうかどうか

### レビュアー
@shizunaito @Asuforce
