### PR TITLE
ユーザープロフィールにMicroContentを表示する

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -40,7 +40,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     private var balloonViews = [BalloonView]()
     private var isEnterBackground: Bool = false             //バックグラウンド中かどうか
     
-    static let originalProfileSize = CGSize(width: 300, height: 390)
+    static let originalProfileSize = CGSize(width: 300, height: 480)
     static let originalProfilePoint = CGPoint(x: (screenSize.width - originalProfileSize.width)/2, y: (screenSize.height - originalProfileSize.height)/2)
 
     private var tutorialView: TutorialView?
@@ -255,6 +255,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         if let micropost = micropost {
             MicropostUserProfile.fetchUserProfile(userID: micropost.userID) { profile in
                 self.profileView.profile = profile
+                self.profileView.microContent = micropost
                 self.activityIndicator.stopAnimating()
                 self.view.addSubview(self.profileView)
             }

--- a/piyopiyo/Classes/Helpers/ColorPalette.swift
+++ b/piyopiyo/Classes/Helpers/ColorPalette.swift
@@ -11,4 +11,5 @@ import UIKit
 struct ColorPalette {
     static let navigationBarButtonTintColor = UIColor.white
     static let navigationBarBackgroundColor = UIColor(red: 105/255, green: 185/255, blue: 86/255, alpha: 0.5)
+    static let microContentTextViewBorderColor = UIColor.gray
 }

--- a/piyopiyo/Classes/Views/ProfileView.swift
+++ b/piyopiyo/Classes/Views/ProfileView.swift
@@ -24,6 +24,14 @@ class ProfileView: UIView {
         }
     }
     
+    @IBOutlet weak var microContentTextView: UITextView! {
+        didSet {
+            microContentTextView.layer.cornerRadius = 5
+            microContentTextView.layer.borderWidth = 1
+            microContentTextView.layer.borderColor = ColorPalette.microContentTextViewBorderColor.cgColor
+        }
+    }
+    
     @IBOutlet weak var userNameLabel: UILabel!
     
     var profile: userProfile? {
@@ -33,6 +41,15 @@ class ProfileView: UIView {
             }
             userNameLabel.text = profile.name
             profileImageView.sd_setImage(with: profile.avatarURL, placeholderImage: UIImage(named: "avatar"))
+        }
+    }
+    
+    var microContent: MicroContent? {
+        didSet {
+            guard let microContent = microContent else {
+                return
+            }
+            microContentTextView.text = microContent.content
         }
     }
     

--- a/piyopiyo/Xibs/ProfileView.xib
+++ b/piyopiyo/Xibs/ProfileView.xib
@@ -35,7 +35,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TWs-qF-ZK2">
-                    <rect key="frame" x="243" y="20" width="44" height="44"/>
+                    <rect key="frame" x="243" y="33" width="44" height="44"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="44" id="URm-ve-m85"/>
                         <constraint firstAttribute="width" constant="44" id="s1S-6S-i4B"/>
@@ -85,7 +85,7 @@
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="TWs-qF-ZK2" secondAttribute="trailing" constant="13" id="4te-q9-No5"/>
                 <constraint firstItem="nFI-7O-MLE" firstAttribute="top" secondItem="PRA-8t-NQt" secondAttribute="bottom" constant="30" id="5Eh-pn-vwt"/>
                 <constraint firstItem="tXe-ji-jIM" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="30" id="9z3-ZN-APF"/>
-                <constraint firstItem="TWs-qF-ZK2" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="Flk-Cf-fc2"/>
+                <constraint firstItem="TWs-qF-ZK2" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="13" id="Flk-Cf-fc2"/>
                 <constraint firstItem="PRA-8t-NQt" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="25" id="MNg-Nr-4Yi"/>
                 <constraint firstItem="Pkk-DH-BKU" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="RrI-p7-Ltn"/>
                 <constraint firstItem="nFI-7O-MLE" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" id="X4V-R5-Hl5"/>

--- a/piyopiyo/Xibs/ProfileView.xib
+++ b/piyopiyo/Xibs/ProfileView.xib
@@ -11,30 +11,31 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProfileView" customModule="piyopiyo" customModuleProvider="target">
             <connections>
+                <outlet property="microContentTextView" destination="PRA-8t-NQt" id="8ZZ-Wr-TBf"/>
                 <outlet property="profileImageView" destination="tXe-ji-jIM" id="XIq-ge-KKG"/>
                 <outlet property="userNameLabel" destination="Pkk-DH-BKU" id="6Sc-eX-LIa"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="300" height="390"/>
+            <rect key="frame" x="0.0" y="0.0" width="300" height="480"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="unknown_avatar" translatesAutoresizingMaskIntoConstraints="NO" id="tXe-ji-jIM">
-                    <rect key="frame" x="86" y="61" width="128" height="128"/>
+                    <rect key="frame" x="102" y="50" width="96" height="96"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="128" id="TeQ-yM-Efc"/>
-                        <constraint firstAttribute="height" constant="128" id="iNF-Jr-Vd1"/>
+                        <constraint firstAttribute="width" constant="96" id="TeQ-yM-Efc"/>
+                        <constraint firstAttribute="height" constant="96" id="iNF-Jr-Vd1"/>
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ユーザー名" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pkk-DH-BKU">
-                    <rect key="frame" x="79.5" y="209" width="142" height="33.5"/>
+                    <rect key="frame" x="79.5" y="161" width="142" height="33.5"/>
                     <fontDescription key="fontDescription" type="system" pointSize="28"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TWs-qF-ZK2">
-                    <rect key="frame" x="243" y="13" width="44" height="44"/>
+                    <rect key="frame" x="243" y="20" width="44" height="44"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="44" id="URm-ve-m85"/>
                         <constraint firstAttribute="width" constant="44" id="s1S-6S-i4B"/>
@@ -48,7 +49,7 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nFI-7O-MLE" customClass="ColorButton" customModule="piyopiyo" customModuleProvider="target">
-                    <rect key="frame" x="44" y="283" width="213" height="57"/>
+                    <rect key="frame" x="44" y="388" width="213" height="57"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="213" id="012-Di-mB5"/>
                         <constraint firstAttribute="height" constant="57" id="HPf-C9-Wo2"/>
@@ -70,24 +71,36 @@
                         <action selector="showButtonDidTap:" destination="-1" eventType="touchUpInside" id="bF3-td-VMK"/>
                     </connections>
                 </button>
+                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="PRA-8t-NQt">
+                    <rect key="frame" x="25" y="219.5" width="250" height="138.5"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <string key="text">１２３４５６７８９０１２３４５６７８９０１２３４５６７８９０１２３４５６７８９０１２３４５６７８９０１２３４５６７８９０１２３４５６７８９０１２３４５６７８９０１２３４５６７８９０１２３４５６７８９⭐️１２３４５６７８９０１２３４５６７８９０１２３４５６７８９０１２３４５６７８９🌠１２３４５６７８９０１２３４５６７８９０１２３４５６７８９０１２３４５６７８９０１２３４５６７８９０</string>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                </textView>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <color key="tintColor" cocoaTouchSystemColor="darkTextColor"/>
             <constraints>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="TWs-qF-ZK2" secondAttribute="trailing" constant="13" id="4te-q9-No5"/>
-                <constraint firstItem="tXe-ji-jIM" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="61" id="9z3-ZN-APF"/>
-                <constraint firstItem="TWs-qF-ZK2" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="13" id="Flk-Cf-fc2"/>
+                <constraint firstItem="nFI-7O-MLE" firstAttribute="top" secondItem="PRA-8t-NQt" secondAttribute="bottom" constant="30" id="5Eh-pn-vwt"/>
+                <constraint firstItem="tXe-ji-jIM" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="30" id="9z3-ZN-APF"/>
+                <constraint firstItem="TWs-qF-ZK2" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="Flk-Cf-fc2"/>
+                <constraint firstItem="PRA-8t-NQt" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="25" id="MNg-Nr-4Yi"/>
                 <constraint firstItem="Pkk-DH-BKU" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="RrI-p7-Ltn"/>
                 <constraint firstItem="nFI-7O-MLE" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" id="X4V-R5-Hl5"/>
-                <constraint firstItem="Pkk-DH-BKU" firstAttribute="top" secondItem="tXe-ji-jIM" secondAttribute="bottom" constant="20" id="YmC-x4-A6U"/>
+                <constraint firstItem="Pkk-DH-BKU" firstAttribute="top" secondItem="tXe-ji-jIM" secondAttribute="bottom" constant="15" id="YmC-x4-A6U"/>
+                <constraint firstItem="PRA-8t-NQt" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="boe-Jd-Pm9"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="PRA-8t-NQt" secondAttribute="trailing" constant="25" id="cmm-QW-llU"/>
+                <constraint firstItem="PRA-8t-NQt" firstAttribute="top" secondItem="Pkk-DH-BKU" secondAttribute="bottom" constant="25" id="cnQ-Uv-Wum"/>
                 <constraint firstItem="tXe-ji-jIM" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="e6Y-5G-FcN"/>
                 <constraint firstItem="nFI-7O-MLE" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="eMn-px-NZa"/>
                 <constraint firstItem="tXe-ji-jIM" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="geF-oV-0mw"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="nFI-7O-MLE" secondAttribute="bottom" constant="50" id="v9v-pF-T7J"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="nFI-7O-MLE" secondAttribute="bottom" constant="35" id="v9v-pF-T7J"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
-            <point key="canvasLocation" x="25" y="-18"/>
+            <point key="canvasLocation" x="14" y="27"/>
         </view>
     </objects>
     <resources>


### PR DESCRIPTION
### 何を解決するのか
- ユーザープロフィールにMicroContentを表示するようにした
    - ツイート文字数が長いときにふきだしからはみ出て読めないので、吹き出しをタップすると該当のツイートをプロフィール画面で確認できるように変更した

### 詳細
- プロフィール画面の大きさを変更
- アバター画像のサイズ変更（小さくなった）
- ツイート表示部分の確保
    - 140字でもはみでる可能性があるので、その場合はスクロールできるようになっている
    - （改行も存在する関係で、１４０字を確実に画面内に収めることは諦めてみた）

<img width="250" alt="2017-10-18 14 40 08" src="https://user-images.githubusercontent.com/19523490/31702475-43814ac8-b412-11e7-8f6c-7360f884236f.png">


### 期日
- 急いでいないです

### レビューポイント
- （主に）画面のデザインが適切かどうか

### レビュアー
@shizunaito @Asuforce
