### PR TITLE
認証からTweet表示の遷移を実装

### DIFF
--- a/piyopiyo.xcodeproj/project.pbxproj
+++ b/piyopiyo.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		AF3F1E3D1F90701B004F9456 /* TwitterAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3F1E3C1F90701B004F9456 /* TwitterAuthorization.swift */; };
 		AF4260C41F90B77F00249975 /* TwitterAuthorizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4260C31F90B77F00249975 /* TwitterAuthorizationTests.swift */; };
 		AF4260C61F90C22500249975 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4260C51F90C22500249975 /* Error.swift */; };
+		AF45F1C51F98489200805ABB /* FeedTutorialUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF45F1C41F98489200805ABB /* FeedTutorialUITests.swift */; };
 		AF914D221F908AB00085FE1C /* SwifteriOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF914D211F908AB00085FE1C /* SwifteriOS.framework */; };
 		AFBDE5B91F7A265500441353 /* .gitkeep in Resources */ = {isa = PBXBuildFile; fileRef = AFBDE5B81F7A265500441353 /* .gitkeep */; };
 		AFBDE5BB1F7A267300441353 /* .gitkeep in Resources */ = {isa = PBXBuildFile; fileRef = AFBDE5BA1F7A267300441353 /* .gitkeep */; };
@@ -91,6 +92,7 @@
 		AF3F1E3C1F90701B004F9456 /* TwitterAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterAuthorization.swift; sourceTree = "<group>"; };
 		AF4260C31F90B77F00249975 /* TwitterAuthorizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterAuthorizationTests.swift; sourceTree = "<group>"; };
 		AF4260C51F90C22500249975 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
+		AF45F1C41F98489200805ABB /* FeedTutorialUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedTutorialUITests.swift; sourceTree = "<group>"; };
 		AF914D211F908AB00085FE1C /* SwifteriOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwifteriOS.framework; path = Carthage/Build/iOS/SwifteriOS.framework; sourceTree = "<group>"; };
 		AFBDE5B81F7A265500441353 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		AFBDE5BA1F7A267300441353 /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
@@ -304,6 +306,7 @@
 			children = (
 				AF161F0E1F78A6FF00B2DD73 /* piyopiyoUITests.swift */,
 				AFECFAD21F7DF321001A9A0E /* FeedUITests.swift */,
+				AF45F1C41F98489200805ABB /* FeedTutorialUITests.swift */,
 				AF161F101F78A6FF00B2DD73 /* Info.plist */,
 			);
 			path = piyopiyoUITests;
@@ -514,6 +517,7 @@
 			files = (
 				AF161F0F1F78A6FF00B2DD73 /* piyopiyoUITests.swift in Sources */,
 				AFECFAD31F7DF321001A9A0E /* FeedUITests.swift in Sources */,
+				AF45F1C51F98489200805ABB /* FeedTutorialUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -113,18 +113,6 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     }
     
     func restartView() {
-        let env = ProcessInfo.processInfo.environment
-        let defaults = UserDefaults.standard
-
-        if microContentType == .twitter {
-            if let consumerKey = env["consumerKey"],
-               let consumerSecret = env["consumerSecret"],
-               let oauthToken = defaults.string(forKey: "twitter_key"),
-               let oauthTokenSecret = defaults.string(forKey: "twitter_secret") {
-                microcontents = ContinuityTweets(consumerKey: consumerKey, consumerSecret: consumerSecret, oauthToken: oauthToken, oauthTokenSecret: oauthTokenSecret)
-            }
-        }
-
         if self.isEnterBackground {
             self.isEnterBackground = false
             if self.resetTrigger == ResetBalloonAnimation.none {
@@ -205,16 +193,30 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     
     func startButtonDidTap() {
         UserDefaults.standard.set(true, forKey: "startApp")
-
-        self.microContentType = MicroContentType.twitter
-        self.initializeTwitterAuthorization { result in
-            if !result {
-                self.microContentType = MicroContentType.micropost
-            }
-        }
+        initializeTweets()
 
         makeBalloons(FeedViewController.balloonCount)
         setupBalloons(FeedViewController.balloonCount)
+    }
+
+    private func initializeTweets() {
+        let env = ProcessInfo.processInfo.environment
+        let defaults = UserDefaults.standard
+
+        self.initializeTwitterAuthorization { result in
+            if result {
+                self.microContentType = MicroContentType.twitter
+                if let consumerKey = env["consumerKey"],
+                    let consumerSecret = env["consumerSecret"],
+                    let oauthToken = defaults.string(forKey: "twitter_key"),
+                    let oauthTokenSecret = defaults.string(forKey: "twitter_secret") {
+                    self.microcontents = ContinuityTweets(consumerKey: consumerKey, consumerSecret: consumerSecret, oauthToken: oauthToken, oauthTokenSecret: oauthTokenSecret)
+                    self.restartView()
+                }
+            } else {
+                self.microContentType = MicroContentType.micropost
+            }
+        }
     }
     
     func resetAnimateBalloon() {

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -117,8 +117,10 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         let defaults = UserDefaults.standard
 
         if microContentType == .twitter {
-            if let consumerKey = env["consumerKey"], let consumerSecret = env["consumerSecret"],
-                let oauthToken = defaults.string(forKey: "twitter_key"), let oauthTokenSecret =     defaults.string(forKey: "twitter_secret") {
+            if let consumerKey = env["consumerKey"],
+               let consumerSecret = env["consumerSecret"],
+               let oauthToken = defaults.string(forKey: "twitter_key"),
+               let oauthTokenSecret = defaults.string(forKey: "twitter_secret") {
                 microcontents = ContinuityTweets(consumerKey: consumerKey, consumerSecret: consumerSecret, oauthToken: oauthToken, oauthTokenSecret: oauthTokenSecret)
             }
         }

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -78,13 +78,6 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        let env = ProcessInfo.processInfo.environment
-        let defaults = UserDefaults.standard
-
-        if let consumerKey = env["consumerKey"], let consumerSecret = env["consumerSecret"],
-            let oauthToken = defaults.string(forKey: "twitter_key"), let oauthTokenSecret = defaults.string(forKey: "twitter_secret") {
-            microcontents = ContinuityTweets(consumerKey: consumerKey, consumerSecret: consumerSecret, oauthToken: oauthToken, oauthTokenSecret: oauthTokenSecret)
-        }
 
         if !UserDefaults.standard.bool(forKey: "startApp") {
             tutorialView = TutorialView(frame: self.view.frame)
@@ -120,6 +113,16 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     }
     
     func restartView() {
+        let env = ProcessInfo.processInfo.environment
+        let defaults = UserDefaults.standard
+
+        if microContentType == .twitter {
+            if let consumerKey = env["consumerKey"], let consumerSecret = env["consumerSecret"],
+                let oauthToken = defaults.string(forKey: "twitter_key"), let oauthTokenSecret =     defaults.string(forKey: "twitter_secret") {
+                microcontents = ContinuityTweets(consumerKey: consumerKey, consumerSecret: consumerSecret, oauthToken: oauthToken, oauthTokenSecret: oauthTokenSecret)
+            }
+        }
+
         if self.isEnterBackground {
             self.isEnterBackground = false
             if self.resetTrigger == ResetBalloonAnimation.none {
@@ -200,6 +203,13 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     
     func startButtonDidTap() {
         UserDefaults.standard.set(true, forKey: "startApp")
+
+        self.microContentType = MicroContentType.twitter
+        self.initializeTwitterAuthorization { result in
+            if !result {
+                self.microContentType = MicroContentType.micropost
+            }
+        }
 
         makeBalloons(FeedViewController.balloonCount)
         setupBalloons(FeedViewController.balloonCount)

--- a/piyopiyoUITests/FeedTutorialUITests.swift
+++ b/piyopiyoUITests/FeedTutorialUITests.swift
@@ -1,0 +1,38 @@
+//
+//  FeedTutorialUITests.swift
+//  piyopiyoUITests
+//
+//  Created by shizuna.ito on 2017/10/19.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import XCTest
+@testable import piyopiyo
+
+class FeedTutorialUITests: XCTestCase {
+    private let app = XCUIApplication()
+
+    override func setUp() {
+        super.setUp()
+
+        continueAfterFailure = false
+
+        // 初回の起動をテストする
+        app.launchArguments.append(contentsOf: ["-startApp", "NO"])
+        app.launch()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testTapAppStart() {
+        let startButton = app.buttons["startButton"]
+
+        XCTAssert(startButton.exists)
+
+        startButton.tap()
+
+        XCTAssertFalse(startButton.exists)
+    }
+}

--- a/piyopiyoUITests/FeedUITests.swift
+++ b/piyopiyoUITests/FeedUITests.swift
@@ -16,22 +16,20 @@ class FeedUITests: XCTestCase {
         super.setUp()
 
         continueAfterFailure = false
-        app.launchArguments.append(contentsOf: ["-startApp", "NO"])
+
+        // 2回目以降の起動をテストする
+        app.launchArguments.append(contentsOf: ["-startApp", "YES"])
         app.launch()
     }
     
     override func tearDown() {
         super.tearDown()
     }
-    
-    func testTapAppStart() {
+
+    func testAnimateBalloon() {
         let startButton = app.buttons["startButton"]
         let durationOfBalloon: TimeInterval = 6.0
         
-        XCTAssert(startButton.exists)
-        
-        startButton.tap()
-
         XCTAssertFalse(startButton.exists)
         
         for i in 0..<3 {


### PR DESCRIPTION
### 何を解決するのか
- 『初回にチュートリアルを終えたら認証　→　Tweet表示』の遷移を実装
- それに伴ってFeedのUIテストを「初回」「2回目以降」の2パターンに分割

#### UI
Tweet表示部分は公開リポジトリのため載せていません。

<img width="378" alt="2017-10-19 12 00 40" src="https://user-images.githubusercontent.com/14357415/31752420-c39371f6-b4c5-11e7-942d-55926f07d3ac.gif">

### 詳細
- TutorialViewのstartButtonタップで認証画面に遷移
- 認証から戻って来たらTweetを取得し、表示

### 実機テスト
- [x] Tutorialの「はじめる」ボタンタップで認証に飛ぶか
- [x] 認証から戻った際にTweetが適切に表示されるか

### 期日
ProfileViewへの情報追加もしくは2回目以降のTweet表示の実装前まで
（優先度高めです）

### レビューポイント
- `FeedViewController.swift`
  - `startButtonDidTap()`：Twitter認証の追加
  - `restartView()`：enumの値が`.twitter`の場合`ContinuityTweets`をインスタンス化
- `FeedTutorialUITests.swift`：初回起動時のテスト。チュートリアルの表示を確かめる。
- `FeedUITests.swift`：2回目以降の起動のテストに変更。balloonViewの存在を確かめる。

### レビュアー
@Asuforce @piyoppi 