### PR TITLE
Twitterの場合のプロフィール表示及びTwitterアプリへの遷移

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -105,6 +105,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             queue: OperationQueue.main,
             using: { _ in
                self.restartView()
+               self.setBalloonUserInteractionEnabled(true)
             })
         
         NotificationCenter.default.addObserver (
@@ -369,7 +370,19 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         prepareViewClosing()
         profileBackgroundView.isHidden = true
         showingUserProfile = profileView.profile
-        performSegue(withIdentifier: "showUserFeed", sender: nil)
+
+        switch microContentType {
+        case .twitter:
+            if let id = showingUserProfile?.userID {
+                if let url = URL(string: "twitter://user?id=\(id)") {
+                    if UIApplication.shared.canOpenURL(url) {
+                        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                    }
+                }
+            }
+        case .micropost:
+            performSegue(withIdentifier: "showUserFeed", sender: nil)
+        }
     }
 
     override func didReceiveMemoryWarning() {

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -304,15 +304,21 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         animator.startAnimation()
     }
 
-    func textViewDidTap(_ micropost: MicroContent?) {
+    func textViewDidTap(_ microcontent: MicroContent?) {
         activityIndicator.startAnimating()
         
-        if let micropost = micropost {
-            MicropostUserProfile.fetchUserProfile(userID: micropost.userID) { profile in
-                self.profileView.profile = profile
-                self.profileView.microContent = micropost
-                self.activityIndicator.stopAnimating()
-                self.view.addSubview(self.profileView)
+        if let microcontent = microcontent {
+            switch microContentType {
+            case .twitter:
+                if let tweet = microcontent as? Tweet {
+                    setupProfile(profile: tweet.profile, microContent: tweet)
+                }
+                activityIndicator.stopAnimating()
+            case .micropost:
+                MicropostUserProfile.fetchUserProfile(userID: microcontent.userID) { profile in
+                    self.setupProfile(profile: profile, microContent: microcontent)
+                    self.activityIndicator.stopAnimating()
+                }
             }
         }
         showBackgroundView()
@@ -329,6 +335,12 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         profileBackgroundView.isHidden = true
         setBalloonUserInteractionEnabled(true)
         activityIndicator.stopAnimating()                   //読み込み中インジケータが表示されたままになることを防ぐために実行
+    }
+
+    private func setupProfile(profile: UserProfile, microContent: MicroContent) {
+        profileView.profile = profile
+        profileView.microContent = microContent
+        view.addSubview(profileView)
     }
 
     func restartAnimation() {

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -82,7 +82,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             activityIndicator.layer.zPosition = CGFloat(FeedViewController.resetBalloonCountValue + 3)
         }
     }
-    private var showingUserProfile: userProfile?
+    private var showingUserProfile: UserProfile?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -330,7 +330,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         setBalloonUserInteractionEnabled(true)
         activityIndicator.stopAnimating()                   //読み込み中インジケータが表示されたままになることを防ぐために実行
     }
-    
+
     func restartAnimation() {
         if self.animatingBalloonCount == 0  && self.pendingSetupBalloonCount == 0 {
             self.balloonCycleCount = 0

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -53,7 +53,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
 
     private var tutorialView: TutorialView?
     
-    private var microcontents: ContinuityMicroContents = ContinuityMicroposts()
+    private var microContents: ContinuityMicroContents = ContinuityMicroposts()
     private let profileView = ProfileView(frame: CGRect(origin: FeedViewController.originalProfilePoint, size: FeedViewController.originalProfileSize))
 
     @IBOutlet weak var profileBackgroundView: UIView! {
@@ -225,7 +225,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                     let consumerSecret = env["consumerSecret"],
                     let oauthToken = defaults.string(forKey: "twitter_key"),
                     let oauthTokenSecret = defaults.string(forKey: "twitter_secret") {
-                    self.microcontents = ContinuityTweets(consumerKey: consumerKey, consumerSecret: consumerSecret, oauthToken: oauthToken, oauthTokenSecret: oauthTokenSecret)
+                    self.microContents = ContinuityTweets(consumerKey: consumerKey, consumerSecret: consumerSecret, oauthToken: oauthToken, oauthTokenSecret: oauthTokenSecret)
                     self.restartView()
                 }
             } else {
@@ -251,7 +251,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         balloonView.frame = CGRect(x: FeedViewController.initialBalloonX, y: FeedViewController.initialBalloonY, width: 0, height: 0)
         balloonView.layoutIfNeeded()
         
-        balloonView.micropost = microcontents.getMicroContent()
+        balloonView.micropost = microContents.getMicroContent()
 
         let animator = UIViewPropertyAnimator(duration: duration, curve: .easeIn, animations: nil)
 
@@ -305,19 +305,19 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         animator.startAnimation()
     }
 
-    func textViewDidTap(_ microcontent: MicroContent?) {
+    func textViewDidTap(_ microContent: MicroContent?) {
         activityIndicator.startAnimating()
         
-        if let microcontent = microcontent {
+        if let microContent = microContent {
             switch microContentType {
             case .twitter:
-                if let tweet = microcontent as? Tweet {
+                if let tweet = microContent as? Tweet {
                     setupProfile(profile: tweet.profile, microContent: tweet)
                 }
                 activityIndicator.stopAnimating()
             case .micropost:
-                MicropostUserProfile.fetchUserProfile(userID: microcontent.userID) { profile in
-                    self.setupProfile(profile: profile, microContent: microcontent)
+                MicropostUserProfile.fetchUserProfile(userID: microContent.userID) { profile in
+                    self.setupProfile(profile: profile, microContent: microContent)
                     self.activityIndicator.stopAnimating()
                 }
             }

--- a/piyopiyo/Classes/Controllers/UserFeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/UserFeedViewController.swift
@@ -19,7 +19,7 @@ class UserFeedViewController: UIViewController {
         }
     }
     
-    var profile: userProfile?
+    var profile: UserProfile?
     var microposts = [Micropost]()
 
     override func viewDidLoad() {
@@ -42,7 +42,7 @@ class UserFeedViewController: UIViewController {
         super.didReceiveMemoryWarning()
     }
 
-    private func fetchProfile(profile: userProfile) {
+    private func fetchProfile(profile: UserProfile) {
         nameLabel.text = profile.name
         avatarImageView.sd_setImage(with: profile.avatarURL, placeholderImage: UIImage(named: "avatar"))
     }

--- a/piyopiyo/Classes/Models/MicropostUserProfile.swift
+++ b/piyopiyo/Classes/Models/MicropostUserProfile.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class MicropostUserProfile: userProfile {
+class MicropostUserProfile: UserProfile {
     var userID: String
     var name: String
     var avatarURL: URL?

--- a/piyopiyo/Classes/Models/TwitterUserProfile.swift
+++ b/piyopiyo/Classes/Models/TwitterUserProfile.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class TwitterUserProfile: userProfile {
+class TwitterUserProfile: UserProfile {
     var userID: String
     var name: String
     var avatarURL: URL?

--- a/piyopiyo/Classes/Models/UserProfile.swift
+++ b/piyopiyo/Classes/Models/UserProfile.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol userProfile {
+protocol UserProfile {
     var userID: String { get set }
     var name: String { get set }
     var avatarURL: URL? { get set }

--- a/piyopiyo/Classes/Views/FeedTableViewCell.swift
+++ b/piyopiyo/Classes/Views/FeedTableViewCell.swift
@@ -28,7 +28,7 @@ class FeedTableViewCell: UITableViewCell {
 
     }
     
-    func update(profile: userProfile, micropost: Micropost) {
+    func update(profile: UserProfile, micropost: Micropost) {
         nameLabel.text = profile.name
         avatarImageView.sd_setImage(with: profile.avatarURL, placeholderImage: UIImage(named: "avatar"))
         contentTextView.text = micropost.content

--- a/piyopiyo/Classes/Views/ProfileView.swift
+++ b/piyopiyo/Classes/Views/ProfileView.swift
@@ -34,7 +34,7 @@ class ProfileView: UIView {
     
     @IBOutlet weak var userNameLabel: UILabel!
     
-    var profile: userProfile? {
+    var profile: UserProfile? {
         didSet {
             guard let profile = profile else {
                 return

--- a/piyopiyo/Info.plist
+++ b/piyopiyo/Info.plist
@@ -31,6 +31,10 @@
 			</array>
 		</dict>
 	</array>
+    <key>LSApplicationQueriesSchemes</key>
+    <array>
+        <string>twitter</string>
+    </array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/piyopiyo/Xibs/ProfileView.xib
+++ b/piyopiyo/Xibs/ProfileView.xib
@@ -28,8 +28,8 @@
                         <constraint firstAttribute="height" constant="96" id="iNF-Jr-Vd1"/>
                     </constraints>
                 </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ユーザー名" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pkk-DH-BKU">
-                    <rect key="frame" x="79.5" y="161" width="142" height="33.5"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ユーザー名" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="Pkk-DH-BKU">
+                    <rect key="frame" x="16" y="161" width="268" height="34"/>
                     <fontDescription key="fontDescription" type="system" pointSize="28"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
@@ -85,9 +85,11 @@
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="TWs-qF-ZK2" secondAttribute="trailing" constant="13" id="4te-q9-No5"/>
                 <constraint firstItem="nFI-7O-MLE" firstAttribute="top" secondItem="PRA-8t-NQt" secondAttribute="bottom" constant="30" id="5Eh-pn-vwt"/>
                 <constraint firstItem="tXe-ji-jIM" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="30" id="9z3-ZN-APF"/>
+                <constraint firstItem="Pkk-DH-BKU" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="Ae1-YF-Oeb"/>
                 <constraint firstItem="TWs-qF-ZK2" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="13" id="Flk-Cf-fc2"/>
                 <constraint firstItem="PRA-8t-NQt" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="25" id="MNg-Nr-4Yi"/>
                 <constraint firstItem="Pkk-DH-BKU" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="RrI-p7-Ltn"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="Pkk-DH-BKU" secondAttribute="trailing" constant="16" id="U3P-BR-tXy"/>
                 <constraint firstItem="nFI-7O-MLE" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" id="X4V-R5-Hl5"/>
                 <constraint firstItem="Pkk-DH-BKU" firstAttribute="top" secondItem="tXe-ji-jIM" secondAttribute="bottom" constant="15" id="YmC-x4-A6U"/>
                 <constraint firstItem="PRA-8t-NQt" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="boe-Jd-Pm9"/>


### PR DESCRIPTION
### 何を解決するのか
- Tweetタップでプロフィールが表示されるよう修正
  - アカウント名が長い時文字の大きさを自動調節するよう設定
- ProfileViewの「他のつぶやき」タップでTwitterアプリに遷移
- （副次的に）プロトコル名をuserProfile→UserProfileに修正

### 詳細
Twitterアプリを持っていない時の処理は別PRで対応します

### 実機テスト
- [ ] プロフィール表示が適切に行われるか
- [ ] 「他のつぶやき」タップ時にツイッターアプリが起動し、適切なユーザーが表示されるか

### 期日
急ぎではないです

### レビューポイント
- `FeedViewController.swift`
  - `textViewDidTap`：microcontentがTweetの場合を追加
  - `showUserFeedButtonDidTap`：Tweetの場合Twitterアプリに遷移する処理を追加

### レビュアー
@Asuforce @piyoppi 