### PR TITLE
twitterへの切り替えタイミングを変更

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -31,7 +31,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         case micropost
         case twitter
     }
-    private var microContentType: MicroContentType = MicroContentType.micropost
+    private var microContentType: MicroContentType = .twitter
     
     enum ResetBalloonAnimation {
         case reset                                          //ふきだしループのリセット
@@ -90,6 +90,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         if !UserDefaults.standard.bool(forKey: "startApp") {
             showTutorial()
         } else {
+            initializeTweets()
             makeBalloons(FeedViewController.balloonCount)
             setupBalloons(FeedViewController.balloonCount)
         }
@@ -209,6 +210,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         //初回起動時のみアニメーションが再生されていない状態なのでアニメーションを開始する
         if !UserDefaults.standard.bool(forKey: "startApp") {
             UserDefaults.standard.set(true, forKey: "startApp")
+            initializeTweets()
             makeBalloons(FeedViewController.balloonCount)
             setupBalloons(FeedViewController.balloonCount)
         }

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -90,9 +90,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         if !UserDefaults.standard.bool(forKey: "startApp") {
             showTutorial()
         } else {
-            initializeTweets()
-            makeBalloons(FeedViewController.balloonCount)
-            setupBalloons(FeedViewController.balloonCount)
+            setupContents(FeedViewController.balloonCount)
         }
         profileView.delegate = self
         activityIndicator = UIActivityIndicatorView()
@@ -210,10 +208,14 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         //初回起動時のみアニメーションが再生されていない状態なのでアニメーションを開始する
         if !UserDefaults.standard.bool(forKey: "startApp") {
             UserDefaults.standard.set(true, forKey: "startApp")
-            initializeTweets()
-            makeBalloons(FeedViewController.balloonCount)
-            setupBalloons(FeedViewController.balloonCount)
+            setupContents(FeedViewController.balloonCount)
         }
+    }
+
+    private func setupContents(_ count: Int) {
+        initializeTweets()
+        makeBalloons(count)
+        setupBalloons(count)
     }
 
     private func initializeTweets() {


### PR DESCRIPTION
### 何を解決するのか
- 初回起動時（チュートリアル終了時）以外も **`UserDefaults`にトークンを持っていればTweetを表示する** ようにした。
- 初回起動時もTweetを取得できるまではデフォルトの文字を返すようにした。

### 詳細
#### 初回起動時の流れ変更について
今までは下記のような流れになっていたため、認証して戻ってくるとmicropostが数件流れてしまった。
```
起動　→　microContentType = .micropost　→　Twitter認証　→　.twitterに切り替え
```
これを下記のように変更することにより、Twitter認証に成功した場合は一度もmicropostが表示されないようにした。
```
起動　→　microContentType = .twitter　→　Twitter認証
```

### 実機テスト
- [ ] 2回目以降の起動で適切にTweetが表示されるかどうか

### 期日
急ぎではないです

### レビューポイント
- `FeedViewController.swift`：`initializeTweets()`を呼ぶタイミングが適切かどうか

### レビュアー
@Asuforce @piyoppi 