### PR TITLE
Twitterクライアントがインストールされていない場合にはアラートを表示

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -371,8 +371,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     }
 
     func showUserFeedButtonDidTap() {
-        prepareViewClosing()
-        profileBackgroundView.isHidden = true
+        hideBackgroundView()
         showingUserProfile = profileView.profile
 
         switch microContentType {
@@ -380,11 +379,13 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             if let id = showingUserProfile?.userID {
                 if let url = URL(string: "twitter://user?id=\(id)") {
                     if UIApplication.shared.canOpenURL(url) {
+                        prepareViewClosing()
                         UIApplication.shared.open(url, options: [:], completionHandler: nil)
                     }
                 }
             }
         case .micropost:
+            prepareViewClosing()
             performSegue(withIdentifier: "showUserFeed", sender: nil)
         }
     }

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -237,7 +237,6 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             }
         }
     }
-    
     func resetAnimateBalloon() {
         resetTrigger = ResetBalloonAnimation.reset
         balloonCycleCount = 0
@@ -382,8 +381,8 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                         prepareViewClosing()
                         UIApplication.shared.open(url, options: [:], completionHandler: nil)
                     } else {
-                        let alert: UIAlertController = UIAlertController(title: "ほかのつぶやきを見ることができません", message: "ほかのつぶやきを見るには、Twitterアプリをインストールしてください", preferredStyle:  UIAlertControllerStyle.alert)
-                        let okAction: UIAlertAction = UIAlertAction(title: "OK", style: UIAlertActionStyle.default)
+                        let alert: UIAlertController = UIAlertController(title: "ほかのつぶやきを見ることができません", message: "ほかのつぶやきを見るには、Twitterアプリをインストールしてください", preferredStyle:  .alert)
+                        let okAction: UIAlertAction = UIAlertAction(title: "OK", style: .default)
                         alert.addAction(okAction)
                         present(alert, animated: true, completion: nil)
                     }

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -381,6 +381,11 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                     if UIApplication.shared.canOpenURL(url) {
                         prepareViewClosing()
                         UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                    } else {
+                        let alert: UIAlertController = UIAlertController(title: "ほかのつぶやきを見ることができません", message: "ほかのつぶやきを見るには、Twitterアプリをインストールしてください", preferredStyle:  UIAlertControllerStyle.alert)
+                        let okAction: UIAlertAction = UIAlertAction(title: "OK", style: UIAlertActionStyle.default)
+                        alert.addAction(okAction)
+                        present(alert, animated: true, completion: nil)
                     }
                 }
             }


### PR DESCRIPTION
### 何を解決するのか
- Twitterクライアントがインストールされていない場合は「クライアントアプリをインストールしてね」という旨のアラートを表示します
- クライアントアプリがない場合にふきだしが表示されなくなってしまう不具合があったので、修正を行いました

### 詳細
（スクショを載せられないので、実機にて確認をお願いします）

### 期日
急いでいないです

### レビューポイント
- piyopiyo/Classes/Controllers/FeedViewController.swift
    - ポップアップの表示が正しいかどうか

### 実機テスト
- [x] Twitterクライアントがインストールされている場合に正しく表示できるかどうか
    - （Twitterクライアントが存在する場合の挙動を確認できていないので、実機にて検証をお願いします）

### レビュアー
@shizunaito @Asuforce
