### PR TITLE
tokenが無効になった時の処理を追加

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -256,8 +256,8 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         balloonView.layoutIfNeeded()
 
         if let tweets = microContents as? ContinuityTweets {
-            if !tweets.isAutholized {
-                tweets.isAutholized = true
+            if !tweets.isAuthorized {
+                tweets.isAuthorized = true
                 alert()
                 return
             }

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -257,6 +257,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
 
         if let tweets = microContents as? ContinuityTweets {
             if !tweets.isAutholized {
+                tweets.isAutholized = true
                 alert()
                 return
             }

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -258,7 +258,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         if let tweets = microContents as? ContinuityTweets {
             if !tweets.isAuthorized {
                 tweets.isAuthorized = true
-                alert()
+                alertResetToken()
                 return
             }
         }
@@ -481,7 +481,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         }
     }
 
-    private func alert() {
+    private func alertResetToken() {
         let title = "セッションが切れました"
         let message = "再度Twitter認証が必要です"
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -259,7 +259,6 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             if !tweets.isAuthorized {
                 tweets.isAuthorized = true
                 alertResetToken()
-                return
             }
         }
         
@@ -486,7 +485,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         let message = "再度Twitter認証が必要です"
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let action = UIAlertAction(title: "OK", style: .default, handler: { _ in
-            self.setupContents(FeedViewController.balloonCount, isReset: true)
+            self.initializeTweets(true)
         })
         alert.addAction(action)
         self.present(alert, animated: true, completion: nil)

--- a/piyopiyo/Classes/Helpers/ContinuityTweets.swift
+++ b/piyopiyo/Classes/Helpers/ContinuityTweets.swift
@@ -39,8 +39,12 @@ class ContinuityTweets: ContinuityMicroContents {
     func fetchMicroContents() {
         if !isRequestingTweets {
             isRequestingTweets = true
-            request = Tweet.fetchRandomTweets(swifter: swifter) { randomTweet in
-                if !randomTweet.content.isEmpty {
+            request = Tweet.fetchRandomTweets(swifter: swifter) { randomTweet, error in
+                if let error = error {
+                    self.isRequestingTweets = false
+                }
+
+                if let randomTweet = randomTweet {
                     self.tweets.append(randomTweet)
                 }
 

--- a/piyopiyo/Classes/Helpers/ContinuityTweets.swift
+++ b/piyopiyo/Classes/Helpers/ContinuityTweets.swift
@@ -23,7 +23,7 @@ class ContinuityTweets: ContinuityMicroContents {
     static let maxTweetCount = 50
     static let lowestTweetCount = 15
 
-    var isAutholized = true
+    var isAuthorized = true
 
     init(consumerKey: String, consumerSecret: String, oauthToken: String, oauthTokenSecret: String) {
         self.consumerKey = consumerKey
@@ -45,7 +45,7 @@ class ContinuityTweets: ContinuityMicroContents {
                 if let error = error as? SwifterError {
                     switch error.kind {
                     case .urlResponseError(status: 401, headers: _, errorCode: _):
-                        self.isAutholized = false
+                        self.isAuthorized = false
                     default:
                         break
                     }
@@ -68,7 +68,6 @@ class ContinuityTweets: ContinuityMicroContents {
         if tweets.count < ContinuityTweets.lowestTweetCount {
             fetchMicroContents()
         }
-
         if tweets.count != 0 {
             return tweets.removeFirst()
         } else {

--- a/piyopiyo/Classes/Helpers/ContinuityTweets.swift
+++ b/piyopiyo/Classes/Helpers/ContinuityTweets.swift
@@ -23,6 +23,8 @@ class ContinuityTweets: ContinuityMicroContents {
     static let maxTweetCount = 50
     static let lowestTweetCount = 15
 
+    var isAutholized = true
+
     init(consumerKey: String, consumerSecret: String, oauthToken: String, oauthTokenSecret: String) {
         self.consumerKey = consumerKey
         self.consumerSecret = consumerSecret
@@ -40,7 +42,13 @@ class ContinuityTweets: ContinuityMicroContents {
         if !isRequestingTweets {
             isRequestingTweets = true
             request = Tweet.fetchRandomTweets(swifter: swifter) { randomTweet, error in
-                if let error = error {
+                if let error = error as? SwifterError {
+                    switch error.kind {
+                    case .urlResponseError(status: 401, headers: _, errorCode: _):
+                        self.isAutholized = false
+                    default:
+                        break
+                    }
                     self.isRequestingTweets = false
                 }
 
@@ -60,6 +68,7 @@ class ContinuityTweets: ContinuityMicroContents {
         if tweets.count < ContinuityTweets.lowestTweetCount {
             fetchMicroContents()
         }
+
         if tweets.count != 0 {
             return tweets.removeFirst()
         } else {

--- a/piyopiyo/Classes/Helpers/Error.swift
+++ b/piyopiyo/Classes/Helpers/Error.swift
@@ -10,5 +10,4 @@ import Foundation
 
 enum TwitterClientError : Error {
     case missingEnvironmentKeys
-    case notAuthorized
 }

--- a/piyopiyo/Classes/Helpers/Error.swift
+++ b/piyopiyo/Classes/Helpers/Error.swift
@@ -10,4 +10,5 @@ import Foundation
 
 enum TwitterClientError : Error {
     case missingEnvironmentKeys
+    case notAuthorized
 }

--- a/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
+++ b/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
@@ -26,8 +26,8 @@ class TwitterAuthorization {
         self.consumerSecret = consumerSecret
     }
 
-    func authorize(presentFrom: UIViewController?, handle: @escaping (_ result: Bool) -> Void) {
-        if isAuthorized() {
+    func authorize(isReset: Bool, presentFrom: UIViewController?, handle: @escaping (_ result: Bool) -> Void) {
+        if isAuthorized(), !isReset {
             handle(true)
             return
         }

--- a/piyopiyo/Classes/Models/Tweet.swift
+++ b/piyopiyo/Classes/Models/Tweet.swift
@@ -20,19 +20,21 @@ class Tweet: MicroContent {
         self.profile = profile
     }
 
-    static func fetchRandomTweets(swifter: Swifter, handler: @escaping ((Tweet) -> Void)) -> HTTPRequest {
+    static func fetchRandomTweets(swifter: Swifter, handler: @escaping ((Tweet?, Error?) -> Void)) -> HTTPRequest {
         return swifter.streamRandomSampleTweets(language:  ["ja"], progress: { json in
             guard let content = json["text"].string,
                   let userID = json["user"]["id"].double,
                   let name = json["user"]["name"].string,
                   let url = json["user"]["profile_image_url_https"].string else {
-                handler(Tweet(content: "", userID: "", profile: TwitterUserProfile(name: "", userID: "", avatarURL: nil)))
+                handler(nil, nil)
                 return
             }
             let profile = TwitterUserProfile(name: name, userID: String(userID), avatarURL: URL(string: url))
             let tweet = Tweet(content: content, userID: String(userID), profile: profile)
 
-            handler(tweet)
-        })
+            handler(tweet, nil)
+        }) { error in
+            handler(nil, error)
+        }
     }
 }

--- a/piyopiyoTests/TwitterAuthorizationTests.swift
+++ b/piyopiyoTests/TwitterAuthorizationTests.swift
@@ -35,7 +35,7 @@ class TwitterAuthorizationTests: XCTestCase {
 
         // すでにキーが存在するときは、クロージャの引数にTrueがセットされる（isAuthorized()メソッドの確認）
         let twitterAuthorizationException: XCTestExpectation? = self.expectation(description: "twitterAuthorization")
-        twitterAuthorization!.authorize(presentFrom: UIViewController()) { result in
+        twitterAuthorization!.authorize(isReset: false, presentFrom: UIViewController()) { result in
             XCTAssertTrue(result)
             userDefaults.removeObject(forKey: "twitter_key")
             userDefaults.removeObject(forKey: "twitter_secret")


### PR DESCRIPTION
### 何を解決するのか
ユーザーが持つ`access token`が無効になった時の処理を追加
- tokenが切れていた時はそのアラートを表示
- `OK`をクリックすると認証画面に遷移

### 詳細
- Tweet取得に失敗したらフラグを立てる
- animationにtweetを当てはめた時にフラグが立っていたらアラート表示
- tokenが入っていてもtrueを返さずに認証を実行

#### 遷移のイメージ図
![image uploaded from ios 78](https://user-images.githubusercontent.com/14357415/31873807-8af12828-b800-11e7-8da8-c1a22bab5b1c.jpg)

### 実機テスト
- [x] 認証を切った時にtoken取得画面に遷移するか
- [x] 遷移後認証して戻ってくると適切にtweetが取得されるか

### 期日
リリースに必要な作業なので優先度高めです。

### レビューポイント
- `FeedViewController.swift`：
  - `alert()`の内容が適切か
  - `isReset`でのtoken切れか初回認証かの伝え方が適切か
- `ContinuityTweets.swift`
  - 401エラーへの処理が適切か
- `Tweet.swift`：`fetchRandomTweets`の結果への処理は適切か

### レビュアー
@Asuforce @piyoppi 