### PR TITLE
アプリ情報を追加

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -471,6 +471,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     
     func showAppInformationButtonDidTap() {
         hideBackgroundView()
+        alertInformation()
         resetMiniHiyokoPosition()
     }
     
@@ -489,5 +490,19 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         })
         alert.addAction(action)
         self.present(alert, animated: true, completion: nil)
+    }
+    
+    private func alertInformation() {
+        let alert = UIAlertController(title: "ぴよぴよ", message: "現在のバージョン", preferredStyle: .alert)
+        let update = UIAlertAction(title: "最新にアップデート", style: .default, handler: { _ in
+        })
+        let information = UIAlertAction(title: "アプリ情報", style: .default, handler: { _ in
+        })
+        let close = UIAlertAction(title: "閉じる", style: .cancel, handler: { _ in
+        })
+        alert.addAction(update)
+        alert.addAction(information)
+        alert.addAction(close)
+        present(alert, animated: true, completion: nil)
     }
 }

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -493,13 +493,21 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     }
     
     private func alertInformation() {
-        let alert = UIAlertController(title: "ぴよぴよ", message: "現在のバージョン", preferredStyle: .alert)
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")
+        var message = ""
+        if let version = version {
+            message = "現在のバージョン \(version)"
+        }
+        let alert = UIAlertController(title: "ぴよぴよ", message: message, preferredStyle: .alert)
         let update = UIAlertAction(title: "最新にアップデート", style: .default, handler: { _ in
+            // TODO: 現在のバージョンが最新だったら表示しない。最新じゃなかったらAppStoreのアプリページに飛ばす。
         })
         let information = UIAlertAction(title: "アプリ情報", style: .default, handler: { _ in
-        })
-        let close = UIAlertAction(title: "閉じる", style: .cancel, handler: { _ in
-        })
+            if let url = URL(string: "https://github.com/pepabo-mobile-app-training/piyopiyo") {
+            UIApplication.shared.canOpenURL(url)
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            }})
+        let close = UIAlertAction(title: "閉じる", style: .cancel, handler: nil)
         alert.addAction(update)
         alert.addAction(information)
         alert.addAction(close)


### PR DESCRIPTION
### 何を解決するのか
『アプリ情報』ボタンタップ時の表示や遷移を追加

#### UI
（Tweetを表示しないためにmicropostを表示しています）
<img width="300" alt="2017-09-28 14 40 40" src="https://user-images.githubusercontent.com/14357415/31878327-af3eb5e2-b814-11e7-9f02-e44818ca67c8.gif">

### 詳細
- 現在のバージョン表示
- AppStoreへの遷移アクション追加
- アプリ情報表示ページ（現状github）への遷移アクション追加

### 期日
急ぎではないです

### レビューポイント
- `FeedViewController.swift`：アラートの実装が適切か、また、表示内容は適切か

### レビュアー
@Asuforce @piyoppi 