### PR TITLE
ふきだしのアニメーション秩序が乱れたことを検知してリセットをかける

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -48,6 +48,9 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     private var balloonViews = [BalloonView]()
     private var isEnterBackground: Bool = false             //バックグラウンド中かどうか
     
+    private var recentResetTime: Date?
+    static let intervalTorelanceRate = 0.23
+    
     static let originalProfileSize = CGSize(width: 300, height: 480)
     static let originalProfilePoint = CGPoint(x: (screenSize.width - originalProfileSize.width)/2, y: (screenSize.height - originalProfileSize.height)/2)
 
@@ -290,6 +293,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         }
         
         animator.addCompletion {_ in
+            
             self.animatingBalloonCount -= 1
             
             switch self.resetTrigger {
@@ -298,6 +302,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                 if self.animatingBalloonCount == 0 {
                     if self.pendingSetupBalloonCount == 0 {
                         self.resetTrigger = ResetBalloonAnimation.none
+                        self.recentResetTime = nil
                     }
                     self.balloonCycleCount = 0
                 }
@@ -308,7 +313,16 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
                 if self.balloonCycleCount == (FeedViewController.resetBalloonCountValue - 1) {
                     //リセット条件を満たした場合（ふきだしカウンタが閾値を超えたら）リセットフラグを立てる
                     self.resetTrigger = ResetBalloonAnimation.reset
+                } else if let recentResetTime = self.recentResetTime {
+                    let elapsed = Date().timeIntervalSince(recentResetTime) as Double
+                    let targetInterval = (self.balloonDuration / Double(FeedViewController.balloonCount))
+                    let torelanceSecond = targetInterval * FeedViewController.intervalTorelanceRate
+                    if abs(targetInterval - elapsed) > torelanceSecond {
+                        self.resetTrigger = .reset
+                    }
+                    print(elapsed)
                 }
+                self.recentResetTime = Date()
                 nextBalloon()
             }
         }
@@ -360,6 +374,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             self.balloonCycleCount = 0
             self.setupBalloons(FeedViewController.balloonCount)
             self.resetTrigger = ResetBalloonAnimation.none
+            self.recentResetTime = nil
         }
     }
 

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -48,8 +48,8 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     private var balloonViews = [BalloonView]()
     private var isEnterBackground: Bool = false             //バックグラウンド中かどうか
     
-    private var recentResetTime: Date?
-    static let intervalTorelanceRate = 0.23
+    private var recentResetTime: Date?                      //ふきだし初期位置移動時刻
+    static let intervalTorelanceRate = 0.23                 //ふきだしアニメーション間隔の許容誤差
     
     static let originalProfileSize = CGSize(width: 300, height: 480)
     static let originalProfilePoint = CGPoint(x: (screenSize.width - originalProfileSize.width)/2, y: (screenSize.height - originalProfileSize.height)/2)


### PR DESCRIPTION
### 何を解決するのか
- ふきだしの表示間隔が時たま乱れることがある
    - 表示間隔はほぼ一定のはずなので、間隔を計測して許容範囲を超えた場合にリセットをかけるようにする

### 詳細
- ふきだしの間隔（時間）を計測し、目標時間の28%を許容誤差とする
    - 許容誤差は実測値（プリントデバッグによる）から適当と思われる値を設定した
    - 許容時間を逸脱する場合はアニメーションをリセット

### 期日
- 急いでいません

### レビューポイント
- piyopiyo/Classes/Controllers/FeedViewController.swift
    - [L309](https://github.com/pepabo-mobile-app-training/piyopiyo/compare/auto-reset?expand=1#diff-239b59da1eb6e45e1d3b819625c03114R309) あたりに実装を記述しています
    - このへんの実装に無駄がないかを見ていただければと思います

### レビュアー
@shizunaito @Asuforce
