### PR TITLE
最新バージョンにアップデートするボタンを除外

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -493,16 +493,12 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             message = "現在のバージョン \(version)"
         }
         let alert = UIAlertController(title: "ぴよぴよ", message: message, preferredStyle: .alert)
-        let update = UIAlertAction(title: "最新にアップデート", style: .default, handler: { _ in
-            // TODO: 現在のバージョンが最新だったら表示しない。最新じゃなかったらAppStoreのアプリページに飛ばす。
-        })
         let information = UIAlertAction(title: "アプリ情報", style: .default, handler: { _ in
             if let url = URL(string: "https://github.com/pepabo-mobile-app-training/piyopiyo") {
             UIApplication.shared.canOpenURL(url)
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
             }})
         let close = UIAlertAction(title: "閉じる", style: .cancel, handler: nil)
-        alert.addAction(update)
         alert.addAction(information)
         alert.addAction(close)
         present(alert, animated: true, completion: nil)


### PR DESCRIPTION
### 何を解決するのか
- 最新版にアップデートするボタンを除外した
    - 当面は「アプリ情報」ボタンを押したらAppStoreに飛ばすようにしたいので、当該ボタンが不要になったため

### 詳細
- (とくになし）

### 期日
- リリース時までにはマージする必要があります

### レビューポイント
- 必要な箇所が削除されているかどうか

### レビュアー
@shizunaito
