### PR TITLE
SwiftLintのwarningを修正

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -220,7 +220,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         let env = ProcessInfo.processInfo.environment
         let defaults = UserDefaults.standard
 
-        self.initializeTwitterAuthorization(isReset: isReset) { result in
+        self.initializeTwitterAuthorization(isReset: isReset) { _ in
             guard let consumerKey = env["consumerKey"],
                   let consumerSecret = env["consumerSecret"] else {
                     return

--- a/piyopiyo/Classes/Helpers/APIClient.swift
+++ b/piyopiyo/Classes/Helpers/APIClient.swift
@@ -21,7 +21,7 @@ class APIClient {
             switch response.result {
             case .success(let value):
                 handler(JSON(value))
-            case .failure(let error):
+            case .failure:
                 handler([])
             }
         }

--- a/piyopiyo/Classes/Helpers/Error.swift
+++ b/piyopiyo/Classes/Helpers/Error.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-enum TwitterClientError : Error {
+enum TwitterClientError: Error {
     case missingEnvironmentKeys
 }

--- a/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
+++ b/piyopiyo/Classes/Helpers/TwitterAuthorization.swift
@@ -42,7 +42,7 @@ class TwitterAuthorization {
             self.userDefaults.set(token.key, forKey: "twitter_key")
             self.userDefaults.set(token.secret, forKey: "twitter_secret")
             handle(true)
-        }, failure: { (error) in
+        }, failure: { _ in
             handle(false)
         })
     }

--- a/piyopiyoTests/MicropostTests.swift
+++ b/piyopiyoTests/MicropostTests.swift
@@ -22,7 +22,7 @@ class MicropostTests: XCTestCase {
     func testFatchRandomMicroposts() {
         let fetchRandomMicropostExpectation: XCTestExpectation? = self.expectation(description: "fetchRandomMicroposts")
 
-        Micropost.fetchRandomMicroposts() { microposts in
+        Micropost.fetchRandomMicroposts { microposts in
             XCTAssertEqual(microposts.count, 10)
             fetchRandomMicropostExpectation?.fulfill()
         }


### PR DESCRIPTION
### 何を解決するのか
今までなおし損ねていたSwiftLintのwarningを修正しました

### 詳細
- 使用していない変数名の削除
- クラス定義のsyntax修正

### 期日
急ぎではないです

### レビューポイント
各所修正が適切か

### レビュアー
@piyoppi 