### PR TITLE
ふきだし内テキストの行間を調整

### DIFF
--- a/piyopiyo/Classes/Views/BalloonView.swift
+++ b/piyopiyo/Classes/Views/BalloonView.swift
@@ -26,7 +26,7 @@ class BalloonView: UIView {
             let paragraphStyle = NSMutableParagraphStyle()
             paragraphStyle.lineHeightMultiple = 1.4
             paragraphStyle.lineBreakMode = .byTruncatingTail
-            attributedText.addAttribute(NSAttributedStringKey.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: attributedText.length))
+            attributedText.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: attributedText.length))
             microContentLabel.attributedText = attributedText
         }
     }

--- a/piyopiyo/Classes/Views/BalloonView.swift
+++ b/piyopiyo/Classes/Views/BalloonView.swift
@@ -22,7 +22,13 @@ class BalloonView: UIView {
             guard let micropost = micropost else {
                 return
             }
-            microContentLabel.text = micropost.content
+            //microContentLabel.text = micropost.content
+            let attributedText = NSMutableAttributedString(string: micropost.content)
+            let paragraphStyle = NSMutableParagraphStyle()
+            paragraphStyle.lineHeightMultiple = 1.4
+            paragraphStyle.lineBreakMode = .byTruncatingTail
+            attributedText.addAttribute(NSAttributedStringKey.paragraphStyle, value: paragraphStyle, range: NSMakeRange(0, attributedText.length))
+            microContentLabel.attributedText = attributedText
         }
     }
     

--- a/piyopiyo/Classes/Views/BalloonView.swift
+++ b/piyopiyo/Classes/Views/BalloonView.swift
@@ -26,7 +26,7 @@ class BalloonView: UIView {
             let paragraphStyle = NSMutableParagraphStyle()
             paragraphStyle.lineHeightMultiple = 1.4
             paragraphStyle.lineBreakMode = .byTruncatingTail
-            attributedText.addAttribute(NSAttributedStringKey.paragraphStyle, value: paragraphStyle, range: NSMakeRange(0, attributedText.length))
+            attributedText.addAttribute(NSAttributedStringKey.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: attributedText.length))
             microContentLabel.attributedText = attributedText
         }
     }

--- a/piyopiyo/Xibs/BalloonView.xib
+++ b/piyopiyo/Xibs/BalloonView.xib
@@ -28,7 +28,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="260" height="150"/>
                 </imageView>
                 <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="今日はいい天気だなあ。朝食も美味しかったなあ。" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="19" translatesAutoresizingMaskIntoConstraints="NO" id="36U-W4-47p">
-                    <rect key="frame" x="16" y="6" width="228" height="124"/>
+                    <rect key="frame" x="16" y="0.0" width="228" height="130"/>
                     <fontDescription key="fontDescription" name="HiraMaruProN-W4" family="Hiragino Maru Gothic ProN" pointSize="25"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
@@ -41,7 +41,7 @@
             <constraints>
                 <constraint firstItem="2em-0u-ba3" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="9Za-P0-tJc"/>
                 <constraint firstItem="36U-W4-47p" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="GpK-Fq-LNa"/>
-                <constraint firstItem="36U-W4-47p" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="6" id="Ocg-tE-lYO"/>
+                <constraint firstItem="36U-W4-47p" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="Ocg-tE-lYO"/>
                 <constraint firstItem="2em-0u-ba3" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="ROz-rf-hT2"/>
                 <constraint firstItem="2em-0u-ba3" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="UG3-mj-83Z"/>
                 <constraint firstItem="2em-0u-ba3" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="Vec-bU-dOo"/>

--- a/piyopiyo/Xibs/BalloonView.xib
+++ b/piyopiyo/Xibs/BalloonView.xib
@@ -4,13 +4,13 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13174"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
-        <array key="HiraginoKakuGothic.ttc">
-            <string>HiraginoSans-W3</string>
+        <array key="HiraginoMaruGothProN.ttc">
+            <string>HiraMaruProN-W4</string>
         </array>
     </customFonts>
     <objects>
@@ -28,8 +28,8 @@
                     <rect key="frame" x="0.0" y="0.0" width="260" height="150"/>
                 </imageView>
                 <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="今日はいい天気だなあ。朝食も美味しかったなあ。" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="19" translatesAutoresizingMaskIntoConstraints="NO" id="36U-W4-47p">
-                    <rect key="frame" x="16" y="14" width="228" height="110"/>
-                    <fontDescription key="fontDescription" name="HiraginoSans-W3" family="Hiragino Sans" pointSize="25"/>
+                    <rect key="frame" x="16" y="6" width="228" height="124"/>
+                    <fontDescription key="fontDescription" name="HiraMaruProN-W4" family="Hiragino Maru Gothic ProN" pointSize="25"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                     <connections>
@@ -41,11 +41,11 @@
             <constraints>
                 <constraint firstItem="2em-0u-ba3" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="9Za-P0-tJc"/>
                 <constraint firstItem="36U-W4-47p" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="GpK-Fq-LNa"/>
-                <constraint firstItem="36U-W4-47p" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="14" id="Ocg-tE-lYO"/>
+                <constraint firstItem="36U-W4-47p" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="6" id="Ocg-tE-lYO"/>
                 <constraint firstItem="2em-0u-ba3" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="ROz-rf-hT2"/>
                 <constraint firstItem="2em-0u-ba3" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="UG3-mj-83Z"/>
                 <constraint firstItem="2em-0u-ba3" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="Vec-bU-dOo"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="36U-W4-47p" secondAttribute="bottom" constant="26" id="lag-EZ-Avz"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="36U-W4-47p" secondAttribute="bottom" constant="20" id="lag-EZ-Avz"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="36U-W4-47p" secondAttribute="trailing" constant="16" id="tDe-fk-9FW"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>


### PR DESCRIPTION
### 何を解決するのか
- ふきだし内のテキストの行間を調整した
    - ふきだし内のテキストが読みやすくなった

### 詳細
（スクリーンショットを貼れないので、実機での確認をお願いします）

### 期日
次のバージョンアップまでにはマージしたい

### レビューポイント
- piyopiyo/Classes/Views/BalloonView.swift
    - lineHeight周りの設定が適切かどうかを確認してください

### 実機テスト
- [x] ふきだし内テキストが適切に表示されているか

### レビュアー
@shizunaito @Asuforce
