### PR TITLE
認証せずに戻るとMicropostが表示されるバグを修正

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -475,8 +475,8 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     }
 
     private func alertResetToken() {
-        let title = "セッションが切れました"
-        let message = "再度Twitter認証が必要です"
+        let title = "Twitter認証に失敗しました"
+        let message = "アプリを使用するためには、Twitterで認証する必要があります。"
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let action = UIAlertAction(title: "OK", style: .default, handler: { _ in
             self.initializeTweets(true)

--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -50,7 +50,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
 
     private var tutorialView: TutorialView?
     
-    private var microContents: ContinuityMicroContents = ContinuityMicroposts()
+    private var microContents: ContinuityMicroContents = ContinuityTweets(consumerKey: "", consumerSecret: "", oauthToken: "", oauthTokenSecret: "")
     private let profileView = ProfileView(frame: CGRect(origin: FeedViewController.originalProfilePoint, size: FeedViewController.originalProfileSize))
 
     @IBOutlet weak var profileBackgroundView: UIView! {


### PR DESCRIPTION
### 何を解決するのか
認証せずに戻るとMicropostが表示され、
かつ、再度認証に遷移するためのアラートも表示されなかったので、修正しました

#### UI
<img width="378" alt="2017-09-28 14 40 40" src="https://user-images.githubusercontent.com/14357415/31982180-59d76bce-b992-11e7-9ae4-fadbb9b481eb.gif">

### 詳細

### 期日
申請までにマージしたいです

### レビューポイント
- `FeedViewController.swift`
  - 宣言時のmicrocontentの初期化をmicropost -> tweetに変更
  - `alertResetToken()`：アラート表示の文言を変更

### レビュアー
@Asuforce @piyoppi 