### PR TITLE
通信失敗時の処理を追加

### DIFF
--- a/piyopiyo/Classes/Controllers/FeedViewController.swift
+++ b/piyopiyo/Classes/Controllers/FeedViewController.swift
@@ -79,6 +79,7 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         }
     }
     private var showingUserProfile: UserProfile?
+    private var connectionAlertClosed = false
         
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -242,7 +243,8 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
     private func animateBalloon(_ balloonView: BalloonView, numberOfBalloon: Int, duration: Double) {
         let originBalloonX = FeedViewController.initialBalloonX - FeedViewController.balloonWidth
         let originBalloonY = FeedViewController.initialBalloonY - FeedViewController.balloonHeight
-        
+        let noConnectionText = "通信中…"
+
         latestAppearanceBalloonNumber = numberOfBalloon
         balloonCycleCount += 1
         animatingBalloonCount += 1
@@ -255,10 +257,16 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
             if !tweets.isAuthorized {
                 tweets.isAuthorized = true
                 alertResetToken()
+            } else if !tweets.isConnected {
+                tweets.isConnected = true
+                balloonView.microContentLabel.text = noConnectionText
+                if !connectionAlertClosed {
+                    alertConnection()
+                }
+            } else {
+                balloonView.micropost = microContents.getMicroContent()
             }
         }
-        
-        balloonView.micropost = microContents.getMicroContent()
 
         let animator = UIViewPropertyAnimator(duration: duration, curve: .easeIn, animations: nil)
 
@@ -485,6 +493,17 @@ class FeedViewController: UIViewController, TutorialDelegate, BalloonViewDelegat
         self.present(alert, animated: true, completion: nil)
     }
     
+    private func alertConnection() {
+        let title = "通信状況が不安定です"
+        let message = "ネットワークに接続できる状態にしてください。"
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let action = UIAlertAction(title: "OK", style: .default, handler: { _ in
+            self.connectionAlertClosed = true
+        })
+        alert.addAction(action)
+        self.present(alert, animated: true, completion: nil)
+    }
+
     private func alertInformation() {
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")
         var message = ""

--- a/piyopiyo/Classes/Helpers/ContinuityTweets.swift
+++ b/piyopiyo/Classes/Helpers/ContinuityTweets.swift
@@ -24,6 +24,7 @@ class ContinuityTweets: ContinuityMicroContents {
     static let lowestTweetCount = 15
 
     var isAuthorized = true
+    var isConnected = true
 
     init(consumerKey: String, consumerSecret: String, oauthToken: String, oauthTokenSecret: String) {
         self.consumerKey = consumerKey
@@ -54,6 +55,11 @@ class ContinuityTweets: ContinuityMicroContents {
                         break
                     }
                     self.isRequestingTweets = false
+                } else if let error = error {
+                    if error.localizedDescription == "The Internet connection appears to be offline." {
+                        self.isConnected = false
+                        self.isRequestingTweets = false
+                    }
                 }
 
                 if let randomTweet = randomTweet {


### PR DESCRIPTION
### 何を解決するのか
通信失敗時に下記の処理を行うようにした
- アラート表示
- 吹き出しに通信中表示

#### UI
<img width="378" alt="2017-09-28 14 40 40" src="https://user-images.githubusercontent.com/14357415/31991259-4f492ad8-b9b2-11e7-9033-2863415453af.gif">

### 詳細

### 期日
今日中にお願いしたいです 🙏 

### レビューポイント
- `FeedViewController.swift`
  - `animateBalloon`：通信できていない時balloonViewのラベルを直接指定
  - `alertConnection()`：通信状態が悪い時のアラート

### レビュアー
@Asuforce @piyoppi 